### PR TITLE
Fix domain subdomain splitting and dedupe logic

### DIFF
--- a/src/services/domains.ts
+++ b/src/services/domains.ts
@@ -46,8 +46,8 @@ export function getDomainsHacks(input: string): string[] {
         }
     }
 
-    // Removes duplicates.
-    return new Set(domains).values().toArray();
+    // Removes duplicates while preserving insertion order.
+    return Array.from(new Set(domains));
 }
 
 /**
@@ -89,7 +89,7 @@ export function getSubdomains(domain: string): string[] {
 
     // Split the domain into parts.
     const results: string[] = [];
-    for (let i = 0; i <= domain.length; i++) {
+    for (let i = 1; i <= domain.length; i++) {
         const label = domain.slice(0, i);
         const remainder = domain.slice(i);
         results.push(remainder ? `${label}.${remainder}` : label);


### PR DESCRIPTION
## Summary
- fix duplicate removal in domain hack generation
- avoid generating empty subdomain entries

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d6a35cc28832b8a24c17e950568d4