### PR TITLE
Fix search bar clearing domain names

### DIFF
--- a/src/components/SearchBar.test.tsx
+++ b/src/components/SearchBar.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import SearchBar from './SearchBar';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+jest.mock('next/navigation', () => ({
+    useRouter: jest.fn(),
+    useSearchParams: jest.fn(),
+}));
+
+describe('SearchBar', () => {
+    it('displays search term from query params', () => {
+        (useRouter as jest.Mock).mockReturnValue({ push: jest.fn(), refresh: jest.fn() });
+        (useSearchParams as jest.Mock).mockReturnValue({
+            get: (key: string) => (key === 'term' ? 'example' : null),
+        });
+
+        render(<SearchBar />);
+
+        expect(screen.getByPlaceholderText('Find the perfect domain hack')).toHaveValue('example');
+    });
+});

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -2,13 +2,21 @@
 
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { useRouter } from 'next/navigation';
-import { FormEvent, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { FormEvent, useEffect, useState } from 'react';
 import { SearchIcon, XIcon } from 'lucide-react';
 
 export default function SearchBar() {
     const router = useRouter();
+    const searchParams = useSearchParams();
     const [searchTerm, setSearchTerm] = useState<string>('');
+
+    useEffect(() => {
+        const term = searchParams.get('term');
+        if (term) {
+            setSearchTerm(term);
+        }
+    }, [searchParams]);
 
     const handleSearch = (event: FormEvent) => {
         event.preventDefault();


### PR DESCRIPTION
## Summary
- keep search term visible after navigating to results by reading URL query
- add unit test to verify search bar renders term from query string

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e0c2a1780832b8082452b982e7f77