### PR TITLE
fix: wrap search components in suspense

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,15 @@
 import Carousel from '@/components/Carousel';
 import Feature from '@/components/Feature';
 import SearchBar from '@/components/SearchBar';
+import { Suspense } from 'react';
 
 export default function Home() {
     return (
         <div className="min-h-screen">
             <main className="m-auto flex w-full max-w-4xl flex-col items-center gap-5 p-5 md:p-10">
-                <SearchBar />
+                <Suspense fallback={null}>
+                    <SearchBar />
+                </Suspense>
                 <Carousel />
                 <Feature
                     color="#fcf6bd"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,7 @@ import TypingAnimation from '@/components/ui/typing-animation';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import SearchBar from './SearchBar';
+import { Suspense } from 'react';
 import { Button } from './ui/button';
 import { Info } from 'lucide-react';
 
@@ -19,7 +20,9 @@ export default function Header() {
             </Link>
             {showSearchBar ? (
                 <div className="flex flex-1 items-center justify-between">
-                    <SearchBar />
+                    <Suspense fallback={null}>
+                        <SearchBar />
+                    </Suspense>
                     <div className="hidden min-w-72 md:block" />
                     <Link href="/about" className="hidden md:block">
                         <Button type="button" variant="ghost">


### PR DESCRIPTION
## Summary
- wrap `SearchBar` with React `Suspense` in header and home page to satisfy Next.js hook requirements

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e16868184832b93254bc678a9d60a