### PR TITLE
feat: enhance no results page with illustration

### DIFF
--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useState, useTransition } from 'react';
 import NumberTicker from '@/components/ui/number-ticker';
@@ -141,7 +142,15 @@ export function SearchResults() {
     if (domains.length === 0) {
         return (
             <div className="flex min-h-screen flex-col items-center gap-5 py-24 align-middle">
-                <p className="text-md text-muted-foreground">Oops! No results found</p>
+                <Image
+                    src="/target.svg"
+                    alt="No results illustration"
+                    width={120}
+                    height={120}
+                />
+                <p className="text-md text-muted-foreground text-center">
+                    No domains hit the mark—try a different search!
+                </p>
             </div>
         );
     }


### PR DESCRIPTION
## Summary
- add target illustration to no-results state
- show friendlier message when no domains are found

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*
- `npm install --legacy-peer-deps` *(fails: ENOTEMPTY directory not empty rename)*

------
https://chatgpt.com/codex/tasks/task_e_688e1e231284832bbe5c7ebb1fdffffd