### PR TITLE
chore: remove unused imports

### DIFF
--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useState, useTransition } from 'react';
 import NumberTicker from '@/components/ui/number-ticker';
@@ -17,7 +16,7 @@ import {
 } from '@tanstack/react-table';
 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { ArrowDown, ArrowUp, ArrowUpDown, BadgeCheck, CircleCheck, OctagonX, Star } from 'lucide-react';
+import { ArrowDown, ArrowUp, BadgeCheck } from 'lucide-react';
 
 export const columns: ColumnDef<Domain>[] = [
     {

--- a/src/components/ui/rainbow-button.tsx
+++ b/src/components/ui/rainbow-button.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import type { ButtonHTMLAttributes } from 'react';
 
 import { cn } from '@/lib/utils';
-interface RainbowButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+interface RainbowButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {}
 
 export function RainbowButton({ children, className, ...props }: RainbowButtonProps) {
     return (


### PR DESCRIPTION
## Summary
- remove unused Image and icon imports from SearchResults component
- drop unused React import in RainbowButton

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e513d8a70832b9101e1738b529996