### PR TITLE
refactor: modularize search results

### DIFF
--- a/src/components/SearchResult.tsx
+++ b/src/components/SearchResult.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { TableCell, TableRow } from '@/components/ui/table';
+import { BadgeCheck } from 'lucide-react';
+import { Domain, DomainStatus as DomainStatusEnum } from '@/models/domain';
+
+interface SearchResultProps {
+    domain: Domain;
+}
+
+export function SearchResult({ domain }: SearchResultProps) {
+    const [isAvailable, setIsAvailable] = useState(domain.isAvailable());
+
+    return (
+        <TableRow>
+            <TableCell>
+                <p className="flex min-h-10 flex-grow flex-row items-center truncate align-middle font-extralight">
+                    {domain.getName()}
+                    {isAvailable && domain.getLevel() <= 2 && (
+                        <TooltipProvider>
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <BadgeCheck className="ml-2 h-4 w-4 text-orange-400" />
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                    <p>This is a rare second level domain!</p>
+                                </TooltipContent>
+                            </Tooltip>
+                        </TooltipProvider>
+                    )}
+                </p>
+            </TableCell>
+            <TableCell className="flex justify-end">
+                <DomainStatus domain={domain} onStatusChange={setIsAvailable} />
+            </TableCell>
+        </TableRow>
+    );
+}
+
+function DomainStatus({ domain, onStatusChange }: { domain: Domain; onStatusChange: (available: boolean) => void }) {
+    const [status, setStatus] = useState<DomainStatusEnum>(domain.getStatus());
+
+    useEffect(() => {
+        const fetchStatus = async () => {
+            try {
+                const response = await fetch('/api/domains/status?domain=' + domain.getName());
+                const data = await response.json();
+                const fetchedStatus = data.status.at(0).summary as DomainStatusEnum;
+                domain.setStatus(fetchedStatus);
+                setStatus(fetchedStatus);
+                onStatusChange(domain.isAvailable());
+            } catch (error) {
+                console.error('Error fetching domain status:', error);
+            }
+        };
+
+        fetchStatus();
+    }, [domain, onStatusChange]);
+
+    if (status === DomainStatusEnum.unknown) {
+        return (
+            <Badge className="flex min-h-7 min-w-24 justify-center text-center bg-slate-200 text-slate-800">
+                Checking...
+            </Badge>
+        );
+    }
+
+    return (
+        <Badge
+            className={`flex min-h-7 min-w-24 justify-center text-center ${
+                domain.isAvailable() ? 'bg-green-400 hover:bg-green-600' : 'bg-red-400 hover:bg-red-600'
+            }`}
+        >
+            {domain.isAvailable() ? 'Available' : 'Taken'}
+        </Badge>
+    );
+}
+

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -2,92 +2,20 @@ import dynamic from 'next/dynamic';
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useState, useTransition } from 'react';
 import NumberTicker from '@/components/ui/number-ticker';
-import { Badge } from '@/components/ui/badge';
 import { ThreeDots } from 'react-loader-spinner';
-import { Domain, DomainStatus } from '@/models/domain';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import {
-    ColumnDef,
-    flexRender,
-    getCoreRowModel,
-    getSortedRowModel,
-    SortingState,
-    useReactTable,
-} from '@tanstack/react-table';
-
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { ArrowDown, ArrowUp, BadgeCheck } from 'lucide-react';
+import { Domain } from '@/models/domain';
+import { Table, TableBody, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { SearchResult } from '@/components/SearchResult';
 
 const Player = dynamic(
     () => import('@lottiefiles/react-lottie-player').then((mod) => mod.Player),
     { ssr: false }
 );
 
-export const columns: ColumnDef<Domain>[] = [
-    {
-        accessorKey: 'name',
-        header: 'Domain',
-        cell: ({ cell }) => (
-            <p className="flex min-h-10 flex-grow flex-row items-center truncate align-middle font-extralight">
-                {cell.row.original.getName()}
-                {cell.row.original.isAvailable() && cell.row.original.getLevel() <= 2 && (
-                    <TooltipProvider>
-                        <Tooltip>
-                            <TooltipTrigger asChild>
-                                <BadgeCheck className="ml-2 h-4 w-4 text-orange-400" />
-                            </TooltipTrigger>
-                            <TooltipContent>
-                                <p>This is a rare second level domain!</p>
-                            </TooltipContent>
-                        </Tooltip>
-                    </TooltipProvider>
-                )}
-            </p>
-        ),
-    },
-    {
-        accessorKey: '_isAvailable',
-        header: ({ column }) => {
-            return (
-                <div className="flex flex-row items-center justify-end align-middle">
-                    <p>Status</p>
-                    {column.getIsSorted() === 'asc' ? (
-                        <ArrowUp
-                            className="ml-2 h-4 w-4"
-                            onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
-                        />
-                    ) : (
-                        <ArrowDown
-                            className="ml-2 h-4 w-4"
-                            onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
-                        />
-                    )}
-                </div>
-            );
-        },
-        cell: ({ cell }) => {
-            return (
-                <div className="flex flex-row items-center justify-end align-middle">
-                    <Badge
-                        className={`flex min-h-7 min-w-24 justify-center text-center ${
-                            cell.row.original.isAvailable()
-                                ? 'bg-green-400 hover:bg-green-600'
-                                : 'bg-red-400 hover:bg-red-600'
-                        }`}
-                    >
-                        {cell.row.original.isAvailable() ? 'Available' : 'Taken'}
-                    </Badge>{' '}
-                </div>
-            );
-        },
-    },
-];
-
 export function SearchResults() {
     const searchParams = useSearchParams();
     const [domains, setDomains] = useState<Domain[]>([]);
     const [isPending, startTransition] = useTransition();
-    const [sorting, setSorting] = useState<SortingState>([]);
 
     useEffect(() => {
         startTransition(async () => {
@@ -95,45 +23,14 @@ export function SearchResults() {
                 const term = searchParams.get('term');
                 const response = await fetch(`/api/domains/search?term=${term}`);
                 const data = await response.json();
-                let domains = data.domains.map((name: string) => new Domain(name));
-                
-                // Show initial results immediately
-                setDomains(domains);
-
-                // Check domain statuses sequentially and update UI progressively
-                for (const [index, domain] of domains.entries()) {
-                    const statusResponse = await fetch('/api/domains/status?domain=' + domain.getName());
-                    const statusData = await statusResponse.json();
-                    domain.setStatus(statusData.status.at(0).summary as DomainStatus);
-                    
-                    // Update domains array with the new status
-                    setDomains(currentDomains => {
-                        const updatedDomains = [...currentDomains];
-                        updatedDomains[index] = domain;
-                        return updatedDomains.sort((a: Domain, b: Domain) => {
-                            if (a.isAvailable() && !b.isAvailable()) return -1;
-                            if (!a.isAvailable() && b.isAvailable()) return 1;
-                            return a.getLevel() - b.getLevel();
-                        });
-                    });
-                }
+                const initialDomains = data.domains.map((name: string) => new Domain(name));
+                setDomains(initialDomains);
             } catch (error) {
                 console.error('Error fetching domains:', error);
                 setDomains([]);
             }
         });
     }, [searchParams]);
-
-    const table = useReactTable({
-        data: domains,
-        columns,
-        getCoreRowModel: getCoreRowModel(),
-        onSortingChange: setSorting,
-        getSortedRowModel: getSortedRowModel(),
-        state: {
-            sorting,
-        },
-    });
 
     if (isPending) {
         return (
@@ -147,12 +44,7 @@ export function SearchResults() {
     if (domains.length === 0) {
         return (
             <div className="flex min-h-screen flex-col items-center gap-5 py-24 align-middle">
-                <Player
-                    autoplay
-                    loop
-                    src="/sad-empty-box.json"
-                    style={{ height: 120, width: 120 }}
-                />
+                <Player autoplay loop src="/sad-empty-box.json" style={{ height: 120, width: 120 }} />
                 <p className="text-md text-center text-muted-foreground">
                     No matches found! Give it another shot.
                 </p>
@@ -169,39 +61,19 @@ export function SearchResults() {
                 </p>
                 <Table>
                     <TableHeader>
-                        {table.getHeaderGroups().map((headerGroup) => (
-                            <TableRow key={headerGroup.id}>
-                                {headerGroup.headers.map((header) => {
-                                    return (
-                                        <TableHead key={header.id}>
-                                            {flexRender(header.column.columnDef.header, header.getContext())}
-                                        </TableHead>
-                                    );
-                                })}
-                            </TableRow>
-                        ))}
+                        <TableRow>
+                            <TableHead>Domain</TableHead>
+                            <TableHead className="text-right">Status</TableHead>
+                        </TableRow>
                     </TableHeader>
                     <TableBody>
-                        {table.getRowModel().rows?.length ? (
-                            table.getRowModel().rows.map((row) => (
-                                <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
-                                    {row.getVisibleCells().map((cell) => (
-                                        <TableCell key={cell.id}>
-                                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                                        </TableCell>
-                                    ))}
-                                </TableRow>
-                            ))
-                        ) : (
-                            <TableRow>
-                                <TableCell colSpan={columns.length} className="h-24 text-center">
-                                    No results.
-                                </TableCell>
-                            </TableRow>
-                        )}
+                        {domains.map((domain) => (
+                            <SearchResult key={domain.getName()} domain={domain} />
+                        ))}
                     </TableBody>
                 </Table>
             </main>
         </div>
     );
 }
+


### PR DESCRIPTION
## Summary
- modularize domain search rows
- fetch domain status in dedicated subcomponent

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_688f232a3eb8832bbe6e7fdc00f18ad1