### PR TITLE
feat: add domain detail drawer

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "validator": "^13.12.0",
-    "zustand": "^5.0.2"
+    "zustand": "^5.0.2",
+    "vaul": "^0.8.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Domain, DomainStatus as DomainStatusEnum } from '@/models/domain';
+import { Badge } from '@/components/ui/badge';
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
+
+interface DomainDetailDrawerProps {
+    domain: Domain;
+    status: DomainStatusEnum;
+    open: boolean;
+    onClose: () => void;
+}
+
+export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDetailDrawerProps) {
+    const [isMobile, setIsMobile] = useState(false);
+
+    useEffect(() => {
+        const mq = window.matchMedia('(max-width: 768px)');
+        const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+        setIsMobile(mq.matches);
+        mq.addEventListener('change', handler);
+        return () => mq.removeEventListener('change', handler);
+    }, []);
+
+    return (
+        <Drawer open={open} onOpenChange={(o) => !o && onClose()} direction={isMobile ? 'bottom' : 'right'}>
+            <DrawerContent className={isMobile ? '' : 'h-full w-80 rounded-none'}>
+                <DrawerHeader>
+                    <DrawerTitle>{domain.getName()}</DrawerTitle>
+                </DrawerHeader>
+                <div className="p-6 pt-0">
+                    <Badge
+                        className={`inline-flex h-7 min-w-[8rem] items-center justify-center px-3 ${
+                            status === DomainStatusEnum.unknown
+                                ? 'bg-gray-400'
+                                : status === DomainStatusEnum.error
+                                ? 'bg-yellow-400 hover:bg-yellow-500'
+                                : domain.isAvailable()
+                                ? 'bg-green-400 hover:bg-green-600'
+                                : 'bg-red-400 hover:bg-red-600'
+                        }`}
+                    >
+                        {status === DomainStatusEnum.unknown
+                            ? 'Checking'
+                            : status === DomainStatusEnum.error
+                            ? 'Error'
+                            : domain.isAvailable()
+                            ? 'Available'
+                            : 'Taken'}
+                    </Badge>
+                </div>
+            </DrawerContent>
+        </Drawer>
+    );
+}
+
+export default DomainDetailDrawer;
+

--- a/src/components/SearchResult.tsx
+++ b/src/components/SearchResult.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { TableCell, TableRow } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { Domain, DomainStatus as DomainStatusEnum } from '@/models/domain';
@@ -5,12 +7,14 @@ import { useEffect, useState } from 'react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { AlertCircle, BadgeCheck, Loader2 } from 'lucide-react';
 import { RateLimiter } from '@/lib/rate-limiter';
+import { DomainDetailDrawer } from '@/components/DomainDetailDrawer';
 
 // Create a shared rate limiter instance (1 call per second)
 const statusRateLimiter = new RateLimiter(1);
 
 export function SearchResult({ domain }: { domain: Domain }) {
     const [status, setStatus] = useState<DomainStatusEnum>(DomainStatusEnum.unknown);
+    const [open, setOpen] = useState(false);
 
     useEffect(() => {
         const fetchStatus = async () => {
@@ -37,52 +41,55 @@ export function SearchResult({ domain }: { domain: Domain }) {
     }, [domain]);
 
     return (
-        <TableRow>
-            <TableCell>
-                <p className="flex min-h-10 flex-grow flex-row items-center truncate align-middle font-extralight">
-                    {domain.getName()}
-                    {domain.isAvailable() && domain.getLevel() <= 2 && (
-                        <TooltipProvider>
-                            <Tooltip>
-                                <TooltipTrigger asChild>
-                                    <BadgeCheck className="ml-2 h-4 w-4 text-orange-400" />
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                    <p>This is a rare second level domain!</p>
-                                </TooltipContent>
-                            </Tooltip>
-                        </TooltipProvider>
-                    )}
-                </p>
-            </TableCell>
-            <TableCell className="text-right">
-                <Badge
-                    className={`inline-flex h-7 min-w-[8rem] items-center justify-center px-3 ${
-                        status === DomainStatusEnum.unknown
-                            ? 'bg-gray-400'
-                            : status === DomainStatusEnum.error
-                            ? 'bg-yellow-400 hover:bg-yellow-500'
-                            : domain.isAvailable()
-                            ? 'bg-green-400 hover:bg-green-600'
-                            : 'bg-red-400 hover:bg-red-600'
-                    }`}
-                >
-                    {status === DomainStatusEnum.unknown ? (
-                        <div className="flex items-center gap-2">
-                            <Loader2 className="h-4 w-4 animate-spin text-white" />
-                            <span>Checking</span>
-                        </div>
-                    ) : status === DomainStatusEnum.error ? (
-                        <div className="flex items-center gap-2">
-                            <AlertCircle className="h-4 w-4 text-white" />
-                            <span>Error</span>
-                        </div>
-                    ) : (
-                        domain.isAvailable() ? 'Available' : 'Taken'
-                    )}
-                </Badge>
-            </TableCell>
-        </TableRow>
+        <>
+            <TableRow onClick={() => setOpen(true)} className="cursor-pointer">
+                <TableCell>
+                    <p className="flex min-h-10 flex-grow flex-row items-center truncate align-middle font-extralight">
+                        {domain.getName()}
+                        {domain.isAvailable() && domain.getLevel() <= 2 && (
+                            <TooltipProvider>
+                                <Tooltip>
+                                    <TooltipTrigger asChild>
+                                        <BadgeCheck className="ml-2 h-4 w-4 text-orange-400" />
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                        <p>This is a rare second level domain!</p>
+                                    </TooltipContent>
+                                </Tooltip>
+                            </TooltipProvider>
+                        )}
+                    </p>
+                </TableCell>
+                <TableCell className="text-right">
+                    <Badge
+                        className={`inline-flex h-7 min-w-[8rem] items-center justify-center px-3 ${
+                            status === DomainStatusEnum.unknown
+                                ? 'bg-gray-400'
+                                : status === DomainStatusEnum.error
+                                ? 'bg-yellow-400 hover:bg-yellow-500'
+                                : domain.isAvailable()
+                                ? 'bg-green-400 hover:bg-green-600'
+                                : 'bg-red-400 hover:bg-red-600'
+                        }`}
+                    >
+                        {status === DomainStatusEnum.unknown ? (
+                            <div className="flex items-center gap-2">
+                                <Loader2 className="h-4 w-4 animate-spin text-white" />
+                                <span>Checking</span>
+                            </div>
+                        ) : status === DomainStatusEnum.error ? (
+                            <div className="flex items-center gap-2">
+                                <AlertCircle className="h-4 w-4 text-white" />
+                                <span>Error</span>
+                            </div>
+                        ) : (
+                            domain.isAvailable() ? 'Available' : 'Taken'
+                        )}
+                    </Badge>
+                </TableCell>
+            </TableRow>
+            <DomainDetailDrawer domain={domain} status={status} open={open} onClose={() => setOpen(false)} />
+        </>
     );
 }
 

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import * as React from 'react';
+import * as DrawerPrimitive from 'vaul';
+
+import { cn } from '@/lib/utils';
+
+const Drawer = DrawerPrimitive.Root;
+const DrawerTrigger = DrawerPrimitive.Trigger;
+const DrawerPortal = DrawerPrimitive.Portal;
+const DrawerClose = DrawerPrimitive.Close;
+
+const DrawerOverlay = React.forwardRef<
+    React.ElementRef<typeof DrawerPrimitive.Overlay>,
+    React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+    <DrawerPrimitive.Overlay
+        ref={ref}
+        className={cn('fixed inset-0 z-40 bg-black/50', className)}
+        {...props}
+    />
+));
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
+
+const DrawerContent = React.forwardRef<
+    React.ElementRef<typeof DrawerPrimitive.Content>,
+    React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+    <DrawerPortal>
+        <DrawerOverlay />
+        <DrawerPrimitive.Content
+            ref={ref}
+            className={cn(
+                'fixed z-50 flex flex-col rounded-t-[10px] border bg-background p-6 shadow-lg top-auto left-0 right-0 bottom-0 mt-24 h-auto max-h-[80%] sm:left-auto sm:right-0 sm:top-0 sm:bottom-0 sm:h-full sm:w-80 sm:rounded-l-[10px] sm:rounded-t-none',
+                className,
+            )}
+            {...props}
+        >
+            {children}
+        </DrawerPrimitive.Content>
+    </DrawerPortal>
+));
+DrawerContent.displayName = DrawerPrimitive.Content.displayName;
+
+const DrawerHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn('grid gap-1.5 text-center sm:text-left', className)} {...props} />
+);
+
+const DrawerFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn('mt-auto flex flex-col gap-2', className)} {...props} />
+);
+
+const DrawerTitle = React.forwardRef<
+    React.ElementRef<typeof DrawerPrimitive.Title>,
+    React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+    <DrawerPrimitive.Title
+        ref={ref}
+        className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+        {...props}
+    />
+));
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
+
+const DrawerDescription = React.forwardRef<
+    React.ElementRef<typeof DrawerPrimitive.Description>,
+    React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+    <DrawerPrimitive.Description
+        ref={ref}
+        className={cn('text-sm text-muted-foreground', className)}
+        {...props}
+    />
+));
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName;
+
+export {
+    Drawer,
+    DrawerTrigger,
+    DrawerPortal,
+    DrawerClose,
+    DrawerOverlay,
+    DrawerContent,
+    DrawerHeader,
+    DrawerFooter,
+    DrawerTitle,
+    DrawerDescription,
+};
+


### PR DESCRIPTION
## Summary
- implement DomainDetailDrawer with shadcn drawer component
- add reusable drawer primitive and vaul dependency

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f3e619d54832b8cc1cdbe9e9d9056