### PR TITLE
fix: add explicit boolean type for drawer state

### DIFF
--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -24,7 +24,11 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
     }, []);
 
     return (
-        <Drawer open={open} onOpenChange={(o) => !o && onClose()} direction={isMobile ? 'bottom' : 'right'}>
+        <Drawer
+            open={open}
+            onOpenChange={(openState: boolean) => !openState && onClose()}
+            direction={isMobile ? 'bottom' : 'right'}
+        >
             <DrawerContent className={isMobile ? '' : 'h-full w-80 rounded-none'}>
                 <DrawerHeader>
                     <DrawerTitle>{domain.getName()}</DrawerTitle>


### PR DESCRIPTION
## Summary
- resolve implicit any error in `DomainDetailDrawer` by typing `onOpenChange`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f478f7024832ba3d5f817ded5cb0d