### PR TITLE
fix: use Drawer root component

### DIFF
--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -14,7 +14,12 @@ import {
 
 import { cn } from '@/lib/utils';
 
-const Drawer = DrawerPrimitive;
+// The `vaul` library exports a `Drawer` object whose `Root` property is the
+// actual React component. Exporting the object directly causes TypeScript to
+// treat it as a plain object and not a component, leading to "does not have any
+// construct or call signatures" errors when used in JSX. Map to the `Root`
+// component so `<Drawer />` works as expected.
+const Drawer = DrawerPrimitive.Root;
 
 const DrawerOverlay = React.forwardRef<
     React.ElementRef<typeof DrawerPrimitiveOverlay>,


### PR DESCRIPTION
## Summary
- map `Drawer` to the `vaul` root component to satisfy JSX typings

## Testing
- `npm ci --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lottie-web)*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f4d6a18e8832b8ab047ab079a4d6c