### PR TITLE
refactor: update drawer component

### DIFF
--- a/src/components/SearchResult.tsx
+++ b/src/components/SearchResult.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { AlertCircle, BadgeCheck, Loader2 } from 'lucide-react';
 import { RateLimiter } from '@/lib/rate-limiter';
-import { DomainDetailDrawer } from '@/components/DomainDetailDrawer';
+import DomainDetailDrawer from '@/components/DomainDetailDrawer';
 
 // Create a shared rate limiter instance (1 call per second)
 const statusRateLimiter = new RateLimiter(1);

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,96 +1,109 @@
 'use client';
 
 import * as React from 'react';
-import {
-    Drawer as DrawerPrimitive,
-    DrawerTrigger,
-    DrawerPortal,
-    DrawerClose,
-    DrawerOverlay as DrawerPrimitiveOverlay,
-    DrawerContent as DrawerPrimitiveContent,
-    DrawerTitle as DrawerPrimitiveTitle,
-    DrawerDescription as DrawerPrimitiveDescription,
-} from 'vaul';
+import { Drawer as DrawerPrimitive } from 'vaul';
 
 import { cn } from '@/lib/utils';
 
-// The `vaul` library exports a `Drawer` object whose `Root` property is the
-// actual React component. Exporting the object directly causes TypeScript to
-// treat it as a plain object and not a component, leading to "does not have any
-// construct or call signatures" errors when used in JSX. Map to the `Root`
-// component so `<Drawer />` works as expected.
-const Drawer = DrawerPrimitive.Root;
+const Drawer = ({
+    shouldScaleBackground = true,
+    ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
+    <DrawerPrimitive.Root shouldScaleBackground={shouldScaleBackground} {...props} />
+);
+Drawer.displayName = 'Drawer';
+
+const DrawerTrigger = DrawerPrimitive.Trigger;
+
+const DrawerPortal = DrawerPrimitive.Portal;
+
+const DrawerClose = DrawerPrimitive.Close;
 
 const DrawerOverlay = React.forwardRef<
-    React.ElementRef<typeof DrawerPrimitiveOverlay>,
-    React.ComponentPropsWithoutRef<typeof DrawerPrimitiveOverlay>
+    React.ElementRef<typeof DrawerPrimitive.Overlay>,
+    React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
-    <DrawerPrimitiveOverlay
+    <DrawerPrimitive.Overlay
         ref={ref}
-        className={cn('fixed inset-0 z-40 bg-black/50', className)}
+        className={cn('fixed inset-0 z-50 bg-black/80', className)}
         {...props}
     />
 ));
-DrawerOverlay.displayName = DrawerPrimitiveOverlay.displayName;
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
 
 const DrawerContent = React.forwardRef<
-    React.ElementRef<typeof DrawerPrimitiveContent>,
-    React.ComponentPropsWithoutRef<typeof DrawerPrimitiveContent>
+    React.ElementRef<typeof DrawerPrimitive.Content>,
+    React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
     <DrawerPortal>
         <DrawerOverlay />
-        <DrawerPrimitiveContent
+        <DrawerPrimitive.Content
             ref={ref}
             className={cn(
-                'fixed z-50 flex flex-col rounded-t-[10px] border bg-background p-6 shadow-lg top-auto left-0 right-0 bottom-0 mt-24 h-auto max-h-[80%] sm:left-auto sm:right-0 sm:top-0 sm:bottom-0 sm:h-full sm:w-80 sm:rounded-l-[10px] sm:rounded-t-none',
+                'fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background',
                 className,
             )}
             {...props}
         >
+            <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
             {children}
-        </DrawerPrimitiveContent>
+        </DrawerPrimitive.Content>
     </DrawerPortal>
 ));
-DrawerContent.displayName = DrawerPrimitiveContent.displayName;
+DrawerContent.displayName = 'DrawerContent';
 
-const DrawerHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-    <div className={cn('grid gap-1.5 text-center sm:text-left', className)} {...props} />
+const DrawerHeader = ({
+    className,
+    ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+        className={cn('grid gap-1.5 p-4 text-center sm:text-left', className)}
+        {...props}
+    />
 );
+DrawerHeader.displayName = 'DrawerHeader';
 
-const DrawerFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-    <div className={cn('mt-auto flex flex-col gap-2', className)} {...props} />
+const DrawerFooter = ({
+    className,
+    ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+    <div className={cn('mt-auto flex flex-col gap-2 p-4', className)} {...props} />
 );
+DrawerFooter.displayName = 'DrawerFooter';
 
 const DrawerTitle = React.forwardRef<
-    React.ElementRef<typeof DrawerPrimitiveTitle>,
-    React.ComponentPropsWithoutRef<typeof DrawerPrimitiveTitle>
+    React.ElementRef<typeof DrawerPrimitive.Title>,
+    React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
 >(({ className, ...props }, ref) => (
-    <DrawerPrimitiveTitle
+    <DrawerPrimitive.Title
         ref={ref}
-        className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+        className={cn(
+            'text-lg font-semibold leading-none tracking-tight',
+            className,
+        )}
         {...props}
     />
 ));
-DrawerTitle.displayName = DrawerPrimitiveTitle.displayName;
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
 
 const DrawerDescription = React.forwardRef<
-    React.ElementRef<typeof DrawerPrimitiveDescription>,
-    React.ComponentPropsWithoutRef<typeof DrawerPrimitiveDescription>
+    React.ElementRef<typeof DrawerPrimitive.Description>,
+    React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
 >(({ className, ...props }, ref) => (
-    <DrawerPrimitiveDescription
+    <DrawerPrimitive.Description
         ref={ref}
         className={cn('text-sm text-muted-foreground', className)}
         {...props}
     />
 ));
-DrawerDescription.displayName = DrawerPrimitiveDescription.displayName;
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName;
 
 export {
     Drawer,
-    DrawerTrigger,
     DrawerPortal,
-    DrawerClose,
     DrawerOverlay,
+    DrawerTrigger,
+    DrawerClose,
     DrawerContent,
     DrawerHeader,
     DrawerFooter,


### PR DESCRIPTION
## Summary
- replace Drawer UI component with updated client-side implementation using vaul
- switch SearchResult to default DomainDetailDrawer import

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f53e0c9f8832ba6c16d633dccaa4d