### PR TITLE
feat: fetch TLD info from Domainr

### DIFF
--- a/src/app/api/tlds/info/route.ts
+++ b/src/app/api/tlds/info/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import axios from 'axios';
+
+const DOMAINR_INFO_URL = 'https://domainr.p.rapidapi.com/v2/info';
+const RAPID_API_KEY = process.env.RAPID_API_KEY!;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+    try {
+        const tld = request.nextUrl.searchParams.get('tld');
+        const params = { domain: tld! };
+        const headers = { headers: { 'x-rapidapi-key': RAPID_API_KEY } };
+        const url = `${DOMAINR_INFO_URL}?${new URLSearchParams(params).toString()}`;
+        const response = await axios.get(url, headers);
+        const info = response.data.info?.[0];
+        const summary = info?.summary || 'No additional information is available for this TLD.';
+        return NextResponse.json({ description: summary });
+    } catch (error) {
+        console.error('Error fetching TLD info:', error);
+        return NextResponse.json({ error: 'Failed to fetch data' }, { status: 500 });
+    }
+}
+

--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react';
 import { Domain, DomainStatus as DomainStatusEnum } from '@/models/domain';
 import { Badge } from '@/components/ui/badge';
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
+import { Separator } from '@/components/ui/separator';
+import { getTldInfo, TldInfo } from '@/services/tld-info';
 
 interface DomainDetailDrawerProps {
     domain: Domain;
@@ -14,6 +16,7 @@ interface DomainDetailDrawerProps {
 
 export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDetailDrawerProps) {
     const [isMobile, setIsMobile] = useState(false);
+    const [tldInfo, setTldInfo] = useState<TldInfo | null>(null);
 
     useEffect(() => {
         const mq = window.matchMedia('(max-width: 768px)');
@@ -22,6 +25,10 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
         mq.addEventListener('change', handler);
         return () => mq.removeEventListener('change', handler);
     }, []);
+
+    useEffect(() => {
+        getTldInfo(domain.getTLD()).then(setTldInfo);
+    }, [domain]);
 
     return (
         <Drawer
@@ -33,7 +40,7 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                 <DrawerHeader>
                     <DrawerTitle>{domain.getName()}</DrawerTitle>
                 </DrawerHeader>
-                <div className="p-6 pt-0">
+                <div className="p-6 pt-0 space-y-4">
                     <Badge
                         className={`inline-flex h-7 min-w-[8rem] items-center justify-center px-3 ${
                             status === DomainStatusEnum.unknown
@@ -53,6 +60,28 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                             ? 'Available'
                             : 'Taken'}
                     </Badge>
+
+                    <Separator />
+
+                    <div className="text-sm">
+                        <p className="font-medium">Top-level domain</p>
+                        <p className="mb-2">.{domain.getTLD()}</p>
+                        {tldInfo ? (
+                            <p>
+                                {tldInfo.description}{' '}
+                                <a
+                                    href={tldInfo.wikipediaUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-blue-600 underline"
+                                >
+                                    Learn more on Wikipedia
+                                </a>
+                            </p>
+                        ) : (
+                            <p>Loading TLD info...</p>
+                        )}
+                    </div>
                 </div>
             </DrawerContent>
         </Drawer>

--- a/src/services/tld-info.ts
+++ b/src/services/tld-info.ts
@@ -1,0 +1,25 @@
+export interface TldInfo {
+    description: string;
+    wikipediaUrl: string;
+}
+
+export async function getTldInfo(tld: string): Promise<TldInfo> {
+    try {
+        const res = await fetch(`/api/tlds/info?tld=${tld}`);
+        if (!res.ok) {
+            throw new Error('Failed to fetch TLD info');
+        }
+        const data = await res.json();
+        return {
+            description: data.description ?? 'No additional information is available for this TLD.',
+            wikipediaUrl: `https://en.wikipedia.org/wiki/.${tld}`,
+        };
+    } catch (error) {
+        console.error('Error fetching TLD info:', error);
+        return {
+            description: 'No additional information is available for this TLD.',
+            wikipediaUrl: `https://en.wikipedia.org/wiki/.${tld}`,
+        };
+    }
+}
+


### PR DESCRIPTION
## Summary
- query Domainr's info API to provide TLD descriptions
- show asynchronous TLD details in the domain drawer with Wikipedia link

## Testing
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden - lottie-web)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f706a95c0832b96cd77d8ad63b41c