### PR TITLE
Revert "use smaller font for TLD summary"

### DIFF
--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -41,36 +41,33 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                     <DrawerTitle>{domain.getName()}</DrawerTitle>
                 </DrawerHeader>
                 <div className="p-6 pt-0 space-y-4">
-                    <div className="flex items-center gap-2">
-                        <Badge
-                            className={`inline-flex h-7 min-w-[8rem] items-center justify-center px-3 ${
-                                status === DomainStatusEnum.unknown
-                                    ? 'bg-gray-400'
-                                    : status === DomainStatusEnum.error
-                                    ? 'bg-yellow-400 hover:bg-yellow-500'
-                                    : domain.isAvailable()
-                                    ? 'bg-green-400 hover:bg-green-600'
-                                    : 'bg-red-400 hover:bg-red-600'
-                            }`}
-                        >
-                            {status === DomainStatusEnum.unknown
-                                ? 'Checking'
+                    <Badge
+                        className={`inline-flex h-7 min-w-[8rem] items-center justify-center px-3 ${
+                            status === DomainStatusEnum.unknown
+                                ? 'bg-gray-400'
                                 : status === DomainStatusEnum.error
-                                ? 'Error'
+                                ? 'bg-yellow-400 hover:bg-yellow-500'
                                 : domain.isAvailable()
-                                ? 'Available'
-                                : 'Taken'}
-                        </Badge>
-                        <Badge variant="outline">.{domain.getTLD()}</Badge>
-                    </div>
+                                ? 'bg-green-400 hover:bg-green-600'
+                                : 'bg-red-400 hover:bg-red-600'
+                        }`}
+                    >
+                        {status === DomainStatusEnum.unknown
+                            ? 'Checking'
+                            : status === DomainStatusEnum.error
+                            ? 'Error'
+                            : domain.isAvailable()
+                            ? 'Available'
+                            : 'Taken'}
+                    </Badge>
 
                     <Separator />
 
-                    <div>
-                        <p className="text-sm font-medium">Top-level domain</p>
-                        <p className="mb-2 text-sm">.{domain.getTLD()}</p>
+                    <div className="text-sm">
+                        <p className="font-medium">Top-level domain</p>
+                        <p className="mb-2">.{domain.getTLD()}</p>
                         {tldInfo ? (
-                            <p className="text-xs">
+                            <p>
                                 {tldInfo.description}{' '}
                                 <a
                                     href={tldInfo.wikipediaUrl}
@@ -82,7 +79,7 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                                 </a>
                             </p>
                         ) : (
-                            <p className="text-xs">Loading TLD info...</p>
+                            <p>Loading TLD info...</p>
                         )}
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- revert previous change that added a TLD badge and smaller fonts in the domain details drawer

## Testing
- `npm test` *(fails: jest not found)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lottie-web)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688faea5a470832bac5830c0e0a7ed80