### PR TITLE
style: use smaller font for TLD summary

### DIFF
--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -63,11 +63,11 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
 
                     <Separator />
 
-                    <div className="text-sm">
+                    <div>
                         <p className="font-medium">Top-level domain</p>
                         <p className="mb-2">.{domain.getTLD()}</p>
                         {tldInfo ? (
-                            <p>
+                            <p className="text-sm">
                                 {tldInfo.description}{' '}
                                 <a
                                     href={tldInfo.wikipediaUrl}
@@ -79,7 +79,7 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                                 </a>
                             </p>
                         ) : (
-                            <p>Loading TLD info...</p>
+                            <p className="text-sm">Loading TLD info...</p>
                         )}
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- use a smaller font for TLD descriptions in the domain detail drawer

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fb0da5360832b9125e5d81a0eb25d