### PR TITLE
feat: show TLD label before summary in drawer

### DIFF
--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -66,6 +66,7 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                     <div>
                         {tldInfo ? (
                             <p className="text-xs">
+                                <span className="font-bold">.{domain.getTLD()}:</span>{' '}
                                 {tldInfo.description}{' '}
                                 <a
                                     href={tldInfo.wikipediaUrl}


### PR DESCRIPTION
## Summary
- show TLD in bold before the TLD description in DomainDetailDrawer

## Testing
- `npm test` *(fails: jest not found)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden for lottie-web)*

------
https://chatgpt.com/codex/tasks/task_e_688fc5734a10832ba2ed7e054f0598b4