### PR TITLE
feat: show domain status details

### DIFF
--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Domain, DomainStatus as DomainStatusEnum } from '@/models/domain';
+import {
+    Domain,
+    DomainStatus as DomainStatusEnum,
+    DOMAIN_STATUS_DESCRIPTIONS,
+} from '@/models/domain';
 import { Badge } from '@/components/ui/badge';
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
 import { Separator } from '@/components/ui/separator';
@@ -65,6 +69,18 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                             ? 'Available'
                             : 'Taken'}
                     </Badge>
+
+                    <Separator />
+
+                    <div>
+                        <p className="text-xs">
+                            <span className="font-bold">Status:</span>{' '}
+                            <span className="capitalize">{status}</span>
+                        </p>
+                        <p className="text-xs">
+                            {DOMAIN_STATUS_DESCRIPTIONS[status]}
+                        </p>
+                    </div>
 
                     <Separator />
 

--- a/src/models/domain.ts
+++ b/src/models/domain.ts
@@ -76,3 +76,27 @@ const DOMAIN_AVAILABLE_STATUS_VALUES = new Set([
     DomainStatus.premium,
     DomainStatus.transferable,
 ]);
+
+export const DOMAIN_STATUS_DESCRIPTIONS: Record<DomainStatus, string> = {
+    [DomainStatus.active]: 'Domain is currently active and in use.',
+    [DomainStatus.claimed]: 'Domain has been claimed and is not available.',
+    [DomainStatus.deleting]: 'Domain is in the process of being deleted.',
+    [DomainStatus.disallowed]: 'Domain cannot be registered.',
+    [DomainStatus.dpml]: 'Domain is blocked by the DPML program.',
+    [DomainStatus.expiring]: 'Domain registration is expiring soon.',
+    [DomainStatus.inactive]: 'Domain is available for registration.',
+    [DomainStatus.invalid]: 'Domain is not valid.',
+    [DomainStatus.marketed]: 'Domain is for sale by registry or reseller.',
+    [DomainStatus.parked]: 'Domain is registered but not in active use.',
+    [DomainStatus.pending]: 'Domain registration is pending.',
+    [DomainStatus.premium]: 'Domain is available at a premium price.',
+    [DomainStatus.priced]: 'Domain has a listed purchase price.',
+    [DomainStatus.reserved]: 'Domain is reserved by the registry.',
+    [DomainStatus.suffix]: 'Domain is a known suffix.',
+    [DomainStatus.tld]: 'Domain is a top level domain.',
+    [DomainStatus.transferable]: 'Domain can be transferred from another registrar.',
+    [DomainStatus.undelegated]: 'Domain is registered but lacks DNS delegation.',
+    [DomainStatus.unknown]: 'Domain status is unknown.',
+    [DomainStatus.zone]: 'Domain is a DNS zone.',
+    [DomainStatus.error]: 'An error occurred while fetching domain status.',
+};


### PR DESCRIPTION
## Summary
- display current domain status and description in the drawer
- map Domainr status codes to human-readable descriptions

## Testing
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lottie-web)*
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689045774480832b849ffb6c9137b9b1