### PR TITLE
Align drawer status description inline

### DIFF
--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -76,9 +76,6 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                     <div>
                         <p className="text-xs">
                             <span className="font-bold">Status:</span>{' '}
-                            <span className="capitalize">{status}</span>
-                        </p>
-                        <p className="text-xs">
                             {DOMAIN_STATUS_DESCRIPTIONS[status]}
                         </p>
                     </div>


### PR DESCRIPTION
## Summary
- show domain status description on same line as status label in drawer

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: peer dependency conflict)
- `npm install --legacy-peer-deps` *(fails: 403 fetching lottie-web)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_689059d5e894832b897129e34e52f093