### PR TITLE
feat: sort domain search results by level

### DIFF
--- a/src/components/SearchResults.test.tsx
+++ b/src/components/SearchResults.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { SearchResults } from './SearchResults';
+import { useSearchParams } from 'next/navigation';
+
+jest.mock('next/navigation', () => ({
+    useSearchParams: jest.fn(),
+}));
+
+jest.mock('@/components/DomainDetailDrawer', () => () => null);
+
+jest.mock('@/lib/rate-limiter', () => ({
+    RateLimiter: class {
+        add<T>(task: () => Promise<T>): Promise<T> {
+            return task();
+        }
+    },
+}));
+
+describe('SearchResults', () => {
+    beforeEach(() => {
+        (useSearchParams as jest.Mock).mockReturnValue({
+            get: (key: string) => (key === 'term' ? 'example' : null),
+        });
+
+        global.fetch = jest.fn((url: string) => {
+            if (url.startsWith('/api/domains/search')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ domains: ['c.com', 'b.a.com'] }),
+                } as Response);
+            }
+
+            if (url.startsWith('/api/domains/status')) {
+                return Promise.resolve({
+                    ok: true,
+                    json: async () => ({ status: [{ summary: 'inactive' }] }),
+                } as Response);
+            }
+
+            return Promise.reject(new Error('Unknown URL'));
+        }) as jest.Mock;
+    });
+
+    it('orders domains by level', async () => {
+        render(<SearchResults />);
+
+        const rows = await screen.findAllByRole('row');
+        expect(rows[1]).toHaveTextContent('c.com');
+        expect(rows[2]).toHaveTextContent('b.a.com');
+    });
+});
+

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -24,6 +24,9 @@ export function SearchResults() {
                 const response = await fetch(`/api/domains/search?term=${term}`);
                 const data = await response.json();
                 const initialDomains = data.domains.map((name: string) => new Domain(name));
+                initialDomains.sort((a, b) =>
+                    a.getLevel() - b.getLevel() || a.getName().localeCompare(b.getName()),
+                );
                 setDomains(initialDomains);
             } catch (error) {
                 console.error('Error fetching domains:', error);


### PR DESCRIPTION
## Summary
- sort fetched domain hacks by domain level so top-level entries show first
- add test ensuring lower-level domains render before higher-level ones

## Testing
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68905cc8a634832ba1af7a89dc89b723