### PR TITLE
fix: add domain types to search sort comparator

### DIFF
--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -24,7 +24,7 @@ export function SearchResults() {
                 const response = await fetch(`/api/domains/search?term=${term}`);
                 const data = await response.json();
                 const initialDomains = data.domains.map((name: string) => new Domain(name));
-                initialDomains.sort((a, b) =>
+                initialDomains.sort((a: Domain, b: Domain) =>
                     a.getLevel() - b.getLevel() || a.getName().localeCompare(b.getName()),
                 );
                 setDomains(initialDomains);


### PR DESCRIPTION
## Summary
- specify Domain type for sort comparator in search results

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689066312b70832bbb704a95ed0c377c