### PR TITLE
Reduce status badge width and shorten checking text

### DIFF
--- a/src/components/SearchResult.tsx
+++ b/src/components/SearchResult.tsx
@@ -62,7 +62,7 @@ export function SearchResult({ domain }: { domain: Domain }) {
                 </TableCell>
                 <TableCell className="text-right">
                     <Badge
-                        className={`inline-flex h-7 min-w-[8rem] items-center justify-center px-3 ${
+                        className={`inline-flex h-7 min-w-[6rem] items-center justify-center px-3 ${
                             status === DomainStatusEnum.unknown
                                 ? 'bg-gray-400'
                                 : status === DomainStatusEnum.error
@@ -75,7 +75,7 @@ export function SearchResult({ domain }: { domain: Domain }) {
                         {status === DomainStatusEnum.unknown ? (
                             <div className="flex items-center gap-2">
                                 <Loader2 className="h-4 w-4 animate-spin text-white" />
-                                <span>Checking</span>
+                                <span>…</span>
                             </div>
                         ) : status === DomainStatusEnum.error ? (
                             <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- tighten status badge by shortening minimum width
- display an ellipsis while status is loading instead of the word "Checking"

## Testing
- `npm test` *(fails: jest: not found)*
- `npm ci` *(fails: ERESOLVE unable to resolve dependency tree)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lottie-web)*

------
https://chatgpt.com/codex/tasks/task_e_68906b7723cc832ba68ecceae3754e91