### PR TITLE
Add active domain link in detail drawer

### DIFF
--- a/src/components/DomainDetailDrawer.test.tsx
+++ b/src/components/DomainDetailDrawer.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { Domain, DomainStatus } from '@/models/domain';
+import DomainDetailDrawer from './DomainDetailDrawer';
+
+jest.mock('@/components/ui/drawer', () => ({
+    Drawer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    DrawerContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    DrawerHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    DrawerTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('@/components/ui/separator', () => ({
+    Separator: () => <div />,
+}));
+
+jest.mock('@/services/tld-info', () => ({
+    getTldInfo: jest.fn().mockResolvedValue(null),
+}));
+
+describe('DomainDetailDrawer', () => {
+    it('renders link to domain when status is active', () => {
+        const domain = new Domain('example.com');
+        render(
+            <DomainDetailDrawer
+                domain={domain}
+                status={DomainStatus.active}
+                open={true}
+                onClose={() => {}}
+            />,
+        );
+        const link = screen.getByRole('link', { name: 'example.com' });
+        expect(link).toHaveAttribute('href', 'https://example.com');
+    });
+
+    it('does not render link when status is not active', () => {
+        const domain = new Domain('example.com');
+        render(
+            <DomainDetailDrawer
+                domain={domain}
+                status={DomainStatus.claimed}
+                open={true}
+                onClose={() => {}}
+            />,
+        );
+        const link = screen.queryByRole('link', { name: 'example.com' });
+        expect(link).toBeNull();
+    });
+});
+

--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -79,6 +79,23 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                             {DOMAIN_STATUS_DESCRIPTIONS[status]}
                         </p>
                     </div>
+                    {status === DomainStatusEnum.active && (
+                        <>
+                            <Separator />
+                            <div>
+                                <p className="text-xs">
+                                    <a
+                                        href={`https://${domain.getName()}`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="text-blue-600 underline"
+                                    >
+                                        {domain.getName()}
+                                    </a>
+                                </p>
+                            </div>
+                        </>
+                    )}
 
                     <Separator />
 


### PR DESCRIPTION
## Summary
- show a hyperlink to the domain when its status is active
- add tests verifying link appears only for active domains

## Testing
- `npm test` *(fails: jest not found)*
- `npm install --force` *(fails: 403 Forbidden for lottie-web)*

------
https://chatgpt.com/codex/tasks/task_e_6890902bf9f4832bb23e18ec5d0d0784