### PR TITLE
feat: add registrar purchase links for available domains

### DIFF
--- a/src/components/DomainDetailDrawer.test.tsx
+++ b/src/components/DomainDetailDrawer.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import DomainDetailDrawer from './DomainDetailDrawer';
+import { Domain, DomainStatus } from '@/models/domain';
+
+jest.mock('@/components/ui/drawer', () => ({
+    Drawer: ({ children }: any) => <div>{children}</div>,
+    DrawerContent: ({ children }: any) => <div>{children}</div>,
+    DrawerHeader: ({ children }: any) => <div>{children}</div>,
+    DrawerTitle: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('@/services/tld-info', () => ({
+    getTldInfo: jest.fn(() => Promise.resolve({ description: 'Test', wikipediaUrl: 'https://example.com' })),
+}));
+
+describe('DomainDetailDrawer', () => {
+    beforeAll(() => {
+        Object.defineProperty(window, 'matchMedia', {
+            writable: true,
+            value: jest.fn().mockImplementation((query) => ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addEventListener: jest.fn(),
+                removeEventListener: jest.fn(),
+                dispatchEvent: jest.fn(),
+            })),
+        });
+    });
+
+    it('shows registrar links when domain is available', async () => {
+        const domain = new Domain('example.com');
+        domain.setStatus(DomainStatus.inactive);
+        render(
+            <DomainDetailDrawer domain={domain} status={domain.getStatus()} open={true} onClose={() => {}} />,
+        );
+
+        const godaddyLink = await screen.findByRole('link', { name: /GoDaddy/i });
+        const namecheapLink = screen.getByRole('link', { name: /Namecheap/i });
+        const googleLink = screen.getByRole('link', { name: /Google Domains/i });
+
+        expect(godaddyLink).toHaveAttribute(
+            'href',
+            `https://www.godaddy.com/domainsearch/find?domainToCheck=${domain.getName()}`,
+        );
+        expect(namecheapLink).toHaveAttribute(
+            'href',
+            `https://www.namecheap.com/domains/registration/results/?domain=${domain.getName()}`,
+        );
+        expect(googleLink).toHaveAttribute(
+            'href',
+            `https://domains.google.com/registrar/search?searchTerm=${domain.getName()}`,
+        );
+    });
+
+    it('does not show registrar links when domain is not available', async () => {
+        const domain = new Domain('example.com');
+        domain.setStatus(DomainStatus.active);
+        render(
+            <DomainDetailDrawer domain={domain} status={domain.getStatus()} open={true} onClose={() => {}} />,
+        );
+
+        expect(screen.queryByText(/Buy this domain:/i)).toBeNull();
+    });
+});

--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -100,6 +100,47 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                             <p className="text-sm">Loading TLD info...</p>
                         )}
                     </div>
+
+                    {domain.isAvailable() && (
+                        <>
+                            <Separator />
+                            <div className="text-xs">
+                                <p className="font-bold">Buy this domain:</p>
+                                <ul className="list-disc pl-4 space-y-1">
+                                    <li>
+                                        <a
+                                            href={`https://www.godaddy.com/domainsearch/find?domainToCheck=${domain.getName()}`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="text-blue-600 underline"
+                                        >
+                                            GoDaddy
+                                        </a>
+                                    </li>
+                                    <li>
+                                        <a
+                                            href={`https://www.namecheap.com/domains/registration/results/?domain=${domain.getName()}`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="text-blue-600 underline"
+                                        >
+                                            Namecheap
+                                        </a>
+                                    </li>
+                                    <li>
+                                        <a
+                                            href={`https://domains.google.com/registrar/search?searchTerm=${domain.getName()}`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="text-blue-600 underline"
+                                        >
+                                            Google Domains
+                                        </a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </>
+                    )}
                 </div>
             </DrawerContent>
         </Drawer>


### PR DESCRIPTION
## Summary
- show purchase links to GoDaddy, Namecheap and Google Domains when a domain is available
- test link display logic in DomainDetailDrawer

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm ci --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lottie-web)*

------
https://chatgpt.com/codex/tasks/task_e_6891909730a4832b826fad0b3329f71c