### PR TITLE
Reposition registrar buttons and cleanup domain detail drawer

### DIFF
--- a/src/components/DomainDetailDrawer.test.tsx
+++ b/src/components/DomainDetailDrawer.test.tsx
@@ -71,7 +71,8 @@ describe('DomainDetailDrawer', () => {
         render(
             <DomainDetailDrawer domain={domain} status={domain.getStatus()} open={true} onClose={() => {}} />,
         );
-
-        expect(screen.queryByText(/Buy this domain:/i)).toBeNull();
+        expect(screen.queryByRole('button', { name: /GoDaddy/i })).toBeNull();
+        expect(screen.queryByRole('button', { name: /Namecheap/i })).toBeNull();
+        expect(screen.queryByRole('button', { name: /Hover/i })).toBeNull();
     });
 });

--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -74,6 +74,47 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                 <div className="p-6 pt-0 space-y-4">
                     <Separator />
 
+                    {domain.isAvailable() && (
+                        <>
+                            <div className="space-y-2">
+                                <Button
+                                    className="w-full bg-green-400 text-white hover:bg-green-600"
+                                    onClick={() =>
+                                        window.open(
+                                            `https://www.godaddy.com/domainsearch/find?domainToCheck=${domain.getName()}`,
+                                            '_blank',
+                                        )
+                                    }
+                                >
+                                    GoDaddy
+                                </Button>
+                                <Button
+                                    className="w-full bg-green-400 text-white hover:bg-green-600"
+                                    onClick={() =>
+                                        window.open(
+                                            `https://www.namecheap.com/domains/registration/results/?domain=${domain.getName()}`,
+                                            '_blank',
+                                        )
+                                    }
+                                >
+                                    Namecheap
+                                </Button>
+                                <Button
+                                    className="w-full bg-green-400 text-white hover:bg-green-600"
+                                    onClick={() =>
+                                        window.open(
+                                            `https://www.hover.com/domains/results?q=${domain.getName()}`,
+                                            '_blank',
+                                        )
+                                    }
+                                >
+                                    Hover
+                                </Button>
+                            </div>
+                            <Separator />
+                        </>
+                    )}
+
                     <div>
                         <p className="text-xs">
                             <span className="font-bold">{status}:</span>{' '}
@@ -99,56 +140,6 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                             <p className="text-sm">Loading TLD info...</p>
                         )}
                     </div>
-
-                    {domain.isAvailable() && (
-                        <>
-                            <Separator />
-                            <div className="text-xs">
-                                <p className="font-bold">Buy this domain:</p>
-                                <ul className="list-disc pl-4 space-y-1">
-                                    <li>
-                                        <Button
-                                            variant="secondary"
-                                            onClick={() =>
-                                                window.open(
-                                                    `https://www.godaddy.com/domainsearch/find?domainToCheck=${domain.getName()}`,
-                                                    '_blank',
-                                                )
-                                            }
-                                        >
-                                            GoDaddy
-                                        </Button>
-                                    </li>
-                                    <li>
-                                        <Button
-                                            variant="secondary"
-                                            onClick={() =>
-                                                window.open(
-                                                    `https://www.namecheap.com/domains/registration/results/?domain=${domain.getName()}`,
-                                                    '_blank',
-                                                )
-                                            }
-                                        >
-                                            Namecheap
-                                        </Button>
-                                    </li>
-                                    <li>
-                                        <Button
-                                            variant="secondary"
-                                            onClick={() =>
-                                                window.open(
-                                                    `https://www.hover.com/domains/results?q=${domain.getName()}`,
-                                                    '_blank',
-                                                )
-                                            }
-                                        >
-                                            Hover
-                                        </Button>
-                                    </li>
-                                </ul>
-                            </div>
-                        </>
-                    )}
                 </div>
             </DrawerContent>
         </Drawer>


### PR DESCRIPTION
## Summary
- move domain registrar buttons before status in the drawer
- restyle registrar buttons to green full-width actions and drop heading text
- adjust tests for new registrar button handling

## Testing
- `npm install` *(fails: ERESOLVE unable to resolve dependency tree)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden - lottie-web)*
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68919f8017b4832b805e283c14fbd5d9