### PR TITLE
Use standard link for TLD info and style registrar buttons blue

### DIFF
--- a/src/components/DomainDetailDrawer.test.tsx
+++ b/src/components/DomainDetailDrawer.test.tsx
@@ -62,6 +62,9 @@ describe('DomainDetailDrawer', () => {
             '_blank',
         );
 
+        const learnMoreLink = await screen.findByRole('link', { name: /Learn more on Wikipedia/i });
+        expect(learnMoreLink).toHaveAttribute('href', 'https://example.com');
+
         openSpy.mockRestore();
     });
 

--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -78,7 +78,7 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                         <>
                             <div className="space-y-2">
                                 <Button
-                                    className="w-full bg-green-400 text-white hover:bg-green-600"
+                                    className="w-full bg-blue-400 text-white hover:bg-blue-600"
                                     onClick={() =>
                                         window.open(
                                             `https://www.godaddy.com/domainsearch/find?domainToCheck=${domain.getName()}`,
@@ -89,7 +89,7 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                                     GoDaddy
                                 </Button>
                                 <Button
-                                    className="w-full bg-green-400 text-white hover:bg-green-600"
+                                    className="w-full bg-blue-400 text-white hover:bg-blue-600"
                                     onClick={() =>
                                         window.open(
                                             `https://www.namecheap.com/domains/registration/results/?domain=${domain.getName()}`,
@@ -100,7 +100,7 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                                     Namecheap
                                 </Button>
                                 <Button
-                                    className="w-full bg-green-400 text-white hover:bg-green-600"
+                                    className="w-full bg-blue-400 text-white hover:bg-blue-600"
                                     onClick={() =>
                                         window.open(
                                             `https://www.hover.com/domains/results?q=${domain.getName()}`,
@@ -129,12 +129,14 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                             <p className="text-xs">
                                 <span className="font-bold">.{domain.getTLD()}:</span>{' '}
                                 {tldInfo.description}{' '}
-                                <Button
-                                    variant="secondary"
-                                    onClick={() => window.open(tldInfo.wikipediaUrl, '_blank')}
+                                <a
+                                    href={tldInfo.wikipediaUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-blue-600 underline"
                                 >
                                     Learn more on Wikipedia
-                                </Button>
+                                </a>
                             </p>
                         ) : (
                             <p className="text-sm">Loading TLD info...</p>


### PR DESCRIPTION
## Summary
- Render TLD Wikipedia link as a standard anchor instead of a button
- Color registrar action buttons blue for better distinction
- Add test for TLD Wikipedia link

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_6891a407830c832ba440b97360f70344