### PR TITLE
Use Porkbun registrar instead of Hover

### DIFF
--- a/src/components/DomainDetailDrawer.test.tsx
+++ b/src/components/DomainDetailDrawer.test.tsx
@@ -39,7 +39,7 @@ describe('DomainDetailDrawer', () => {
 
         const godaddyButton = await screen.findByRole('button', { name: /GoDaddy/i });
         const namecheapButton = screen.getByRole('button', { name: /Namecheap/i });
-        const hoverButton = screen.getByRole('button', { name: /Hover/i });
+        const porkbunButton = screen.getByRole('button', { name: /Porkbun/i });
 
         fireEvent.click(godaddyButton);
         expect(openSpy).toHaveBeenNthCalledWith(
@@ -55,10 +55,10 @@ describe('DomainDetailDrawer', () => {
             '_blank',
         );
 
-        fireEvent.click(hoverButton);
+        fireEvent.click(porkbunButton);
         expect(openSpy).toHaveBeenNthCalledWith(
             3,
-            `https://www.hover.com/domains/results?q=${domain.getName()}`,
+            `https://porkbun.com/checkout/search?q=${domain.getName()}`,
             '_blank',
         );
 
@@ -76,6 +76,6 @@ describe('DomainDetailDrawer', () => {
         );
         expect(screen.queryByRole('button', { name: /GoDaddy/i })).toBeNull();
         expect(screen.queryByRole('button', { name: /Namecheap/i })).toBeNull();
-        expect(screen.queryByRole('button', { name: /Hover/i })).toBeNull();
+        expect(screen.queryByRole('button', { name: /Porkbun/i })).toBeNull();
     });
 });

--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -103,12 +103,12 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                                     className="w-full bg-blue-400 text-white hover:bg-blue-600"
                                     onClick={() =>
                                         window.open(
-                                            `https://www.hover.com/domains/results?q=${domain.getName()}`,
+                                            `https://porkbun.com/checkout/search?q=${domain.getName()}`,
                                             '_blank',
                                         )
                                     }
                                 >
-                                    Hover
+                                    Porkbun
                                 </Button>
                             </div>
                             <Separator />


### PR DESCRIPTION
## Summary
- swap Hover domain registrar link for Porkbun
- update tests for new registrar

## Testing
- `npm install` *(failed: unable to resolve dependency tree)*
- `npm install --legacy-peer-deps` *(failed: 403 Forbidden - lottie-web)*
- `npx prettier src/components/DomainDetailDrawer.tsx src/components/DomainDetailDrawer.test.tsx -w` *(failed: Cannot find package 'prettier-plugin-tailwindcss')*
- `npm test` *(failed: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891ab0efaa8832ba094beaadd6cd0e2