### PR TITLE
feat: add whois lookup API

### DIFF
--- a/src/app/api/domains/whois/route.ts
+++ b/src/app/api/domains/whois/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import axios from 'axios';
+
+const WHOIS_BASE_URL = 'https://domains-api.p.rapidapi.com/v1/whois';
+const RAPID_API_KEY = process.env.RAPID_API_KEY!;
+const RAPID_API_HOST = 'domains-api.p.rapidapi.com';
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+    const domain = request.nextUrl.searchParams.get('domain');
+    if (!domain) {
+        return NextResponse.json({ error: 'Missing domain parameter' }, { status: 400 });
+    }
+
+    try {
+        const url = `${WHOIS_BASE_URL}?${new URLSearchParams({ domain }).toString()}`;
+        const headers = {
+            headers: {
+                'x-rapidapi-key': RAPID_API_KEY,
+                'x-rapidapi-host': RAPID_API_HOST,
+            },
+        };
+        const response = await axios.get(url, headers);
+        return NextResponse.json(response.data);
+    } catch (error) {
+        console.error('Error fetching WHOIS data:', error);
+        return NextResponse.json({ error: 'Failed to fetch WHOIS data' }, { status: 500 });
+    }
+}
+


### PR DESCRIPTION
## Summary
- integrate RapidAPI Domains API for WHOIS lookups via server endpoint
- expose `/api/domains/whois` endpoint
- remove unused client WHOIS service

## Testing
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lottie-web)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891b002fbc4832b97ef28a29e42544f