### PR TITLE
feat: display full WHOIS JSON in detail drawer

### DIFF
--- a/src/components/DomainDetailDrawer.test.tsx
+++ b/src/components/DomainDetailDrawer.test.tsx
@@ -95,6 +95,9 @@ describe('DomainDetailDrawer', () => {
         const registrar = await screen.findByText(/Mock Registrar/);
         expect(registrar).toBeInTheDocument();
 
+        const jsonPre = await screen.findByTestId('whois-json');
+        expect(jsonPre.textContent).toContain('"registrarName": "Mock Registrar"');
+
         (global.fetch as jest.Mock).mockRestore();
     });
 });

--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -180,6 +180,13 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                                                 ).toLocaleDateString()}
                                             </p>
                                         )}
+                                        <p className="text-xs font-bold mt-2">Full WHOIS response:</p>
+                                        <pre
+                                            data-testid="whois-json"
+                                            className="mt-1 whitespace-pre-wrap rounded bg-gray-100 p-2 text-xs"
+                                        >
+                                            {JSON.stringify(whoisInfo, null, 2)}
+                                        </pre>
                                     </>
                                 ) : whoisError ? (
                                     <p className="text-xs">Failed to load WHOIS info</p>


### PR DESCRIPTION
## Summary
- show full WHOIS API response JSON in the domain detail drawer
- verify rendering of raw WHOIS data via tests

## Testing
- `npm test` *(fails: jest not found)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden - lottie-web)*

------
https://chatgpt.com/codex/tasks/task_e_6892ddd4670c832ba51db8e99b3f9cfb