### PR TITLE
Use medium font for About page headings

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -2,7 +2,7 @@ export default function AboutPage() {
     return (
         <div className="min-h-screen">
             <main className="m-auto flex w-full max-w-4xl flex-col gap-3 md:gap-5 p-10">
-                <h2 className="text-lg md:text-xl">What's a domain hack</h2>
+                <h2 className="text-lg md:text-xl font-medium">What's a domain hack</h2>
                 <p className="text-sm md:text-md font-sans font-light">
                     Domain hacks are clever ways of constructing domain names by combining words with TLDs (Top-Level
                     Domains) to create <span className="font-bold">🧠 memorable</span>,{' '}
@@ -14,7 +14,7 @@ export default function AboutPage() {
                     <span className="font-medium">bit.ly</span> and <span className="font-medium">del.icio.us</span>,
                     which are memorable because of their distinctive and playful appearance.
                 </p>
-                <h2 className="text-lg md:text-xl">Why domain hacks are so effective</h2>
+                <h2 className="text-lg md:text-xl font-medium">Why domain hacks are so effective</h2>
                 <p className="text-sm md:text-md font-sans font-light">
                     Well-crafted domain hacks do more than showcase creativity—they make your site more memorable and
                     shareable.
@@ -26,7 +26,7 @@ export default function AboutPage() {
                     <span className="font-bold">🚀 modern, tech-savvy image</span>. It also shows visitors your
                     innovative thinking—a valuable trait in today's digital landscape.
                 </p>
-                <h2 className="text-lg md:text-xl">Build Your Brand Around It</h2>
+                <h2 className="text-lg md:text-xl font-medium">Build Your Brand Around It</h2>
                 <p className="text-sm md:text-md font-sans font-light">
                     A memorable domain hack can become a powerful{' '}
                     <span className="font-bold">✨centerpiece for your brand</span>. By leveraging domain hacks, you can


### PR DESCRIPTION
## Summary
- ensure About page headers use medium font weight for a lighter look

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: dependency conflict)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68944c4008a0832bbf89962c81918437