### PR TITLE
Add MX record lookup and simplify DNS display

### DIFF
--- a/src/app/api/domains/dig/route.ts
+++ b/src/app/api/domains/dig/route.ts
@@ -19,6 +19,13 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         if (cnameRecords.length) {
             records.CNAME = cnameRecords.map(String);
         }
+        const mxRecords = await resolver.resolve(domain, 'MX').catch(() => []);
+        if (mxRecords.length) {
+            // Format as "priority exchange"
+            records.MX = (mxRecords as { priority: number; exchange: string }[]).map(
+                (mx) => `${mx.priority} ${mx.exchange}`,
+            );
+        }
 
         return NextResponse.json({
             result: {

--- a/src/components/DomainDetailDrawer.test.tsx
+++ b/src/components/DomainDetailDrawer.test.tsx
@@ -82,6 +82,7 @@ describe('DomainDetailDrawer', () => {
                             records: {
                                 A: ['1.2.3.4'],
                                 CNAME: ['alias.example.com.'],
+                                MX: ['10 mx.example.com.'],
                             },
                         },
                     }),
@@ -98,9 +99,9 @@ describe('DomainDetailDrawer', () => {
 
         const aRecord = await screen.findByText(/A:/);
         expect(aRecord).toHaveTextContent('1.2.3.4');
-
-        const jsonPre = await screen.findByTestId('dig-json');
-        expect(jsonPre.textContent).toContain('"A": [\n    "1.2.3.4"');
+        const mxRecord = await screen.findByText(/MX:/);
+        expect(mxRecord).toHaveTextContent('10 mx.example.com.');
+        expect(screen.queryByTestId('dig-json')).toBeNull();
 
         (global.fetch as jest.Mock).mockRestore();
     });

--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -166,12 +166,6 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                                                 {values.join(', ')}
                                             </p>
                                         ))}
-                                        <pre
-                                            data-testid="dig-json"
-                                            className="mt-1 whitespace-pre-wrap rounded bg-gray-100 p-2 text-xs"
-                                        >
-                                            {JSON.stringify(digInfo, null, 2)}
-                                        </pre>
                                     </>
                                 ) : digError ? (
                                     <p className="text-xs">Failed to load DNS info</p>


### PR DESCRIPTION
## Summary
- include MX record resolution in dig API
- show only DNS record summary in DomainDetailDrawer
- update tests for MX records and removed raw JSON output

## Testing
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden retrieving lottie-web)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68945855f660832bb4d4e1dfcd525670