### PR TITLE
Remove visit link from search results

### DIFF
--- a/src/components/SearchResult.tsx
+++ b/src/components/SearchResult.tsx
@@ -86,17 +86,7 @@ export function SearchResult({ domain }: { domain: Domain }) {
                                 domain.isAvailable() ? 'Available' : 'Taken'
                             )}
                         </Badge>
-                        {!domain.isAvailable() && (
-                            <a
-                                href={`https://${domain.getName()}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-blue-600 underline"
-                                onClick={(e) => e.stopPropagation()}
-                            >
-                                Visit
-                            </a>
-                        )}
+
                     </div>
                 </TableCell>
             </TableRow>

--- a/src/components/SearchResults.test.tsx
+++ b/src/components/SearchResults.test.tsx
@@ -51,17 +51,14 @@ describe('SearchResults', () => {
         expect(rows[2]).toHaveTextContent('b.a.com');
     });
 
-    it('shows visit link for taken domains', async () => {
+    it('does not show visit link for any domains', async () => {
         render(<SearchResults />);
 
         const rows = await screen.findAllByRole('row');
         const takenRow = rows[1];
         const availableRow = rows[2];
 
-        expect(within(takenRow).getByRole('link', { name: /visit/i })).toHaveAttribute(
-            'href',
-            'https://c.com',
-        );
+        expect(within(takenRow).queryByRole('link', { name: /visit/i })).toBeNull();
         expect(within(availableRow).queryByRole('link', { name: /visit/i })).toBeNull();
     });
 });


### PR DESCRIPTION
## Summary
- remove external visit link from search results
- adjust tests to reflect absence of visit link

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_6894d8930970832b8b60436d28063f4d