### PR TITLE
feat: move website link above DNS records

### DIFF
--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -151,6 +151,21 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                             <span className="font-bold">{status}:</span>{' '}
                             {DOMAIN_STATUS_DESCRIPTIONS[status]}
                         </p>
+                        {!domain.isAvailable() &&
+                            digInfo &&
+                            digInfo.result.records.A &&
+                            digInfo.result.records.A.length > 0 && (
+                                <p className="text-xs mt-2">
+                                    <a
+                                        href={`https://${domain.getName()}`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="text-blue-600 underline"
+                                    >
+                                        Visit website
+                                    </a>
+                                </p>
+                            )}
                     </div>
 
                     {!domain.isAvailable() && (
@@ -159,18 +174,6 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                             <div>
                                 {digInfo ? (
                                     <>
-                                        {digInfo.result.records.A && digInfo.result.records.A.length > 0 && (
-                                            <p className="text-xs mt-2">
-                                                <a
-                                                    href={`https://${domain.getName()}`}
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
-                                                    className="text-blue-600 underline"
-                                                >
-                                                    Visit website
-                                                </a>
-                                            </p>
-                                        )}
                                         <p className="text-xs font-bold mt-2">DNS Records:</p>
                                         {Object.entries(digInfo.result.records).map(([type, values]) => (
                                             <p key={type} className="text-xs">


### PR DESCRIPTION
## Summary
- show website link next to domain status in drawer
- remove duplicate link from DNS section

## Testing
- `npm test` *(fails: jest not found)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden - lottie-web)*

------
https://chatgpt.com/codex/tasks/task_e_6894e3b630f4832b95d3fa9773796355