### PR TITLE
refactor: centralize DigInfo interface in models

### DIFF
--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -11,13 +11,7 @@ import { Button } from '@/components/ui/button';
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
 import { Separator } from '@/components/ui/separator';
 import { getTldInfo, TldInfo } from '@/services/tld-info';
-
-interface DigInfo {
-    result: {
-        domain: string;
-        records: Record<string, string[]>;
-    };
-}
+import { DigInfo } from '@/models/dig';
 
 interface DomainDetailDrawerProps {
     domain: Domain;

--- a/src/models/dig.ts
+++ b/src/models/dig.ts
@@ -1,0 +1,6 @@
+export interface DigInfo {
+    result: {
+        domain: string;
+        records: Record<string, string[]>;
+    };
+}


### PR DESCRIPTION
## Summary
- rename DigInfo model file to `dig.ts`
- update DomainDetailDrawer to import the shared DigInfo type

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895e3aaa4f8832b99b47a705dbd0f9b