### PR TITLE
feat: add whois lookup endpoint

### DIFF
--- a/src/app/api/domains/whois/route.ts
+++ b/src/app/api/domains/whois/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import axios from 'axios';
+
+const WHOIS_URL = 'https://whois-api6.p.rapidapi.com/whois/api/v1/getData';
+const WHOIS_HOST = 'whois-api6.p.rapidapi.com';
+const RAPID_API_KEY = process.env.RAPID_API_KEY!;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+    const domain = request.nextUrl.searchParams.get('domain');
+    if (!domain) {
+        return NextResponse.json({ error: 'Missing domain parameter' }, { status: 400 });
+    }
+
+    try {
+        const response = await axios.post(
+            WHOIS_URL,
+            { query: domain },
+            {
+                headers: {
+                    'Content-Type': 'application/json',
+                    'x-rapidapi-key': RAPID_API_KEY,
+                    'x-rapidapi-host': WHOIS_HOST,
+                },
+            },
+        );
+        return NextResponse.json(response.data);
+    } catch (error) {
+        console.error('Error fetching whois data:', error);
+        return NextResponse.json(
+            { error: 'Failed to fetch whois data' },
+            { status: 500 },
+        );
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `/api/domains/whois` endpoint to fetch WHOIS data via RapidAPI
- refactor WHOIS lookup to use axios for HTTP requests

## Testing
- `npm install` *(fails: unable to resolve dependency tree: react 19 vs vaul peer dependency)*
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895f961ae3c832bba61a866707afb05