### PR TITLE
fix: prevent drawer resizing

### DIFF
--- a/src/components/DomainDetailDrawer.test.tsx
+++ b/src/components/DomainDetailDrawer.test.tsx
@@ -4,7 +4,7 @@ import { Domain, DomainStatus } from '@/models/domain';
 
 jest.mock('@/components/ui/drawer', () => ({
     Drawer: ({ children }: any) => <div>{children}</div>,
-    DrawerContent: ({ children }: any) => <div>{children}</div>,
+    DrawerContent: ({ children, className }: any) => <div className={className}>{children}</div>,
     DrawerHeader: ({ children }: any) => <div>{children}</div>,
     DrawerTitle: ({ children }: any) => <div>{children}</div>,
 }));

--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -67,8 +67,8 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
     if (!domain.isAvailable() && loading) {
         return (
             <Drawer open={open} onOpenChange={(openState: boolean) => !openState && onClose()} direction="bottom">
-                <DrawerContent>
-                    <div className="flex items-center gap-2 text-sm">
+                <DrawerContent className="min-h-[400px]">
+                    <div className="flex flex-1 items-center justify-center gap-2 text-sm">
                         <Loader2 className="h-4 w-4 animate-spin" /> Loading domain details...
                     </div>
                 </DrawerContent>
@@ -78,7 +78,7 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
 
     return (
         <Drawer open={open} onOpenChange={(openState: boolean) => !openState && onClose()} direction="bottom">
-            <DrawerContent>
+            <DrawerContent className="min-h-[400px]">
                 <DrawerHeader>
                     <DrawerTitle className="flex items-center justify-between">
                         <div className="flex items-center gap-2">{domain.getName()}</div>


### PR DESCRIPTION
## Summary
- keep domain detail drawer height stable with a min-height
- update test drawer mock to forward class names

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68965451e660832bbd4b5777b78bb088