### PR TITLE
refactor: share domain status badge component

### DIFF
--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -4,13 +4,14 @@ import { useEffect, useState } from 'react';
 import axios from 'axios';
 import { Loader2 } from 'lucide-react';
 import { Domain, DomainStatus as DomainStatusEnum, DOMAIN_STATUS_DESCRIPTIONS } from '@/models/domain';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
 import { Separator } from '@/components/ui/separator';
 import { getTldInfo, TldInfo } from '@/services/tld-info';
 import { DigInfo } from '@/models/dig';
 import { WhoisInfo } from '@/models/whois';
+import { Badge } from '@/components/ui/badge';
+import DomainStatusBadge from '@/components/DomainStatusBadge';
 
 interface DomainDetailDrawerProps {
     domain: Domain;
@@ -84,27 +85,7 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                         <div className="flex items-center gap-2">{domain.getName()}</div>
                         <div className="flex items-center gap-2">
                             {domain.getLevel() === 1 && <Badge variant="secondary">Exact match</Badge>}
-                            <>
-                                <Badge
-                                    className={`inline-flex h-7 min-w-[8rem] items-center justify-center px-3 ${
-                                        status === DomainStatusEnum.unknown
-                                            ? 'bg-gray-400'
-                                            : status === DomainStatusEnum.error
-                                              ? 'bg-yellow-400 hover:bg-yellow-500'
-                                              : domain.isAvailable()
-                                                ? 'bg-green-400 hover:bg-green-600'
-                                                : 'bg-red-400 hover:bg-red-600'
-                                    }`}
-                                >
-                                    {status === DomainStatusEnum.unknown
-                                        ? 'Checking'
-                                        : status === DomainStatusEnum.error
-                                          ? 'Error'
-                                          : domain.isAvailable()
-                                            ? 'Available'
-                                            : 'Taken'}
-                                </Badge>
-                            </>
+                            <DomainStatusBadge domain={domain} status={status} className="min-w-[8rem]" />
                         </div>
                     </DrawerTitle>
                 </DrawerHeader>

--- a/src/components/DomainStatusBadge.tsx
+++ b/src/components/DomainStatusBadge.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { Domain, DomainStatus as DomainStatusEnum } from '@/models/domain';
+import { AlertCircle, Loader2 } from 'lucide-react';
+
+interface DomainStatusBadgeProps {
+    domain: Domain;
+    status: DomainStatusEnum;
+    className?: string;
+}
+
+export function DomainStatusBadge({ domain, status, className }: DomainStatusBadgeProps) {
+    return (
+        <Badge
+            className={cn(
+                'inline-flex h-7 min-w-[6rem] items-center justify-center px-3',
+                status === DomainStatusEnum.unknown
+                    ? 'bg-gray-400'
+                    : status === DomainStatusEnum.error
+                      ? 'bg-yellow-400 hover:bg-yellow-500'
+                      : domain.isAvailable()
+                        ? 'bg-green-400 hover:bg-green-600'
+                        : 'bg-red-400 hover:bg-red-600',
+                className,
+            )}
+        >
+            {status === DomainStatusEnum.unknown ? (
+                <div className="flex items-center gap-2">
+                    <Loader2 className="h-4 w-4 animate-spin text-white" />
+                </div>
+            ) : status === DomainStatusEnum.error ? (
+                <div className="flex items-center gap-2">
+                    <AlertCircle className="h-4 w-4 text-white" />
+                    <span>Error</span>
+                </div>
+            ) : domain.isAvailable() ? (
+                'Available'
+            ) : (
+                'Taken'
+            )}
+        </Badge>
+    );
+}
+
+export default DomainStatusBadge;
+

--- a/src/components/SearchResult.tsx
+++ b/src/components/SearchResult.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import { TableCell, TableRow } from '@/components/ui/table';
-import { Badge } from '@/components/ui/badge';
 import { Domain, DomainStatus as DomainStatusEnum } from '@/models/domain';
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { AlertCircle, BadgeCheck, Loader2 } from 'lucide-react';
+import { BadgeCheck } from 'lucide-react';
 import { RateLimiter } from '@/lib/rate-limiter';
 import DomainDetailDrawer from '@/components/DomainDetailDrawer';
+import DomainStatusBadge from '@/components/DomainStatusBadge';
 
 // Create a shared rate limiter instance (1 call per second)
 const statusRateLimiter = new RateLimiter(1);
@@ -62,32 +62,7 @@ export function SearchResult({ domain }: { domain: Domain }) {
                 </TableCell>
                 <TableCell className="text-right">
                     <div className="flex items-center justify-end gap-2">
-                        <Badge
-                            className={`inline-flex h-7 min-w-[6rem] items-center justify-center px-3 ${
-                                status === DomainStatusEnum.unknown
-                                    ? 'bg-gray-400'
-                                    : status === DomainStatusEnum.error
-                                      ? 'bg-yellow-400 hover:bg-yellow-500'
-                                      : domain.isAvailable()
-                                        ? 'bg-green-400 hover:bg-green-600'
-                                        : 'bg-red-400 hover:bg-red-600'
-                            }`}
-                        >
-                            {status === DomainStatusEnum.unknown ? (
-                                <div className="flex items-center gap-2">
-                                    <Loader2 className="h-4 w-4 animate-spin text-white" />
-                                </div>
-                            ) : status === DomainStatusEnum.error ? (
-                                <div className="flex items-center gap-2">
-                                    <AlertCircle className="h-4 w-4 text-white" />
-                                    <span>Error</span>
-                                </div>
-                            ) : domain.isAvailable() ? (
-                                'Available'
-                            ) : (
-                                'Taken'
-                            )}
-                        </Badge>
+                        <DomainStatusBadge domain={domain} status={status} />
                     </div>
                 </TableCell>
             </TableRow>


### PR DESCRIPTION
## Summary
- factor out domain status badge into reusable component
- use the shared status badge in SearchResult and DomainDetailDrawer

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896e710d040832bb2ed059991d966bf