### PR TITLE
Improve loading state in domain detail drawer

### DIFF
--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -69,8 +69,9 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
         return (
             <Drawer open={open} onOpenChange={(openState: boolean) => !openState && onClose()} direction="bottom">
                 <DrawerContent className="min-h-[400px]">
-                    <div className="flex flex-1 items-center justify-center gap-2 text-sm">
-                        <Loader2 className="h-4 w-4 animate-spin" /> Loading domain details...
+                    <div className="flex flex-1 flex-col items-center justify-center gap-4 text-sm text-muted-foreground">
+                        <Loader2 className="h-6 w-6 animate-spin" />
+                        <span>Hang tight, fetching domain details...</span>
                     </div>
                 </DrawerContent>
             </Drawer>


### PR DESCRIPTION
## Summary
- vertically stack loader and message in domain drawer
- enlarge spinner and use muted text with friendly copy

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896ef8776e4832b8227d7bb3f831deb