### PR TITLE
refactor: extract TLD info into dedicated component

### DIFF
--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -7,7 +7,7 @@ import { Domain, DomainStatus as DomainStatusEnum, DOMAIN_STATUS_DESCRIPTIONS } 
 import { Button } from '@/components/ui/button';
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
 import { Separator } from '@/components/ui/separator';
-import { getTldInfo, TldInfo } from '@/services/tld-info';
+import TldInfo from '@/components/TldInfo';
 import { DigInfo } from '@/models/dig';
 import { WhoisInfo } from '@/models/whois';
 import { Badge } from '@/components/ui/badge';
@@ -21,14 +21,10 @@ interface DomainDetailDrawerProps {
 }
 
 export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDetailDrawerProps) {
-    const [tldInfo, setTldInfo] = useState<TldInfo | null>(null);
     const [hasARecord, setHasARecord] = useState(false);
     const [whoisInfo, setWhoisInfo] = useState<WhoisInfo | null>(null);
     const [loading, setLoading] = useState(false);
 
-    useEffect(() => {
-        getTldInfo(domain.getTLD()).then(setTldInfo);
-    }, [domain]);
 
     useEffect(() => {
         if (!open || domain.isAvailable()) {
@@ -182,21 +178,7 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                     )}
 
                     <div>
-                        {tldInfo ? (
-                            <p className="text-xs">
-                                <span className="font-bold">.{domain.getTLD()}:</span> {tldInfo.description}{' '}
-                                <a
-                                    href={tldInfo.wikipediaUrl}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="text-blue-600 underline"
-                                >
-                                    Learn more on Wikipedia
-                                </a>
-                            </p>
-                        ) : (
-                            <p className="text-sm">Loading TLD info...</p>
-                        )}
+                        <TldInfo tld={domain.getTLD()} />
                     </div>
                 </div>
             </DrawerContent>

--- a/src/components/TldInfo.tsx
+++ b/src/components/TldInfo.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getTldInfo, TldInfo as TldInfoType } from '@/services/tld-info';
+
+interface TldInfoProps {
+    tld: string;
+}
+
+export default function TldInfo({ tld }: TldInfoProps) {
+    const [tldInfo, setTldInfo] = useState<TldInfoType | null>(null);
+
+    useEffect(() => {
+        getTldInfo(tld).then(setTldInfo);
+    }, [tld]);
+
+    if (!tldInfo) {
+        return <p className="text-sm">Loading TLD info...</p>;
+    }
+
+    return (
+        <p className="text-xs">
+            <span className="font-bold">.{tld}:</span> {tldInfo.description}{' '}
+            <a
+                href={tldInfo.wikipediaUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 underline"
+            >
+                Learn more on Wikipedia
+            </a>
+        </p>
+    );
+}


### PR DESCRIPTION
## Summary
- pull TLD description and link display into new `TldInfo` component
- integrate `TldInfo` in domain detail drawer

## Testing
- `npm test` *(fails: jest: not found)*
- `npx jest` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_6896f90a8410832b97bcf34fce144753