### PR TITLE
Load TLD info with domain detail data

### DIFF
--- a/src/components/TldInfo.tsx
+++ b/src/components/TldInfo.tsx
@@ -1,28 +1,18 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { apiService, TldInfo as TldInfoType } from '@/services/api';
+import { TldInfo as TldInfoType } from '@/services/api';
 
 interface TldInfoProps {
     tld: string;
+    info: TldInfoType;
 }
 
-export default function TldInfo({ tld }: TldInfoProps) {
-    const [tldInfo, setTldInfo] = useState<TldInfoType | null>(null);
-
-    useEffect(() => {
-        apiService.getTldInfo(tld).then(setTldInfo);
-    }, [tld]);
-
-    if (!tldInfo) {
-        return <p className="text-sm">Loading TLD info...</p>;
-    }
-
+export default function TldInfo({ tld, info }: TldInfoProps) {
     return (
         <p className="text-xs">
-            <span className="font-bold">.{tld}:</span> {tldInfo.description}{' '}
+            <span className="font-bold">.{tld}:</span> {info.description}{' '}
             <a
-                href={tldInfo.wikipediaUrl}
+                href={info.wikipediaUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-blue-600 underline"


### PR DESCRIPTION
## Summary
- fetch TLD metadata together with dig and whois calls
- render TLD info once fetched data is available
- keep drawer spinner visible until TLD info resolves

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689877540818832bad007c03ed6ad49d