### PR TITLE
feat: add whois info section component

### DIFF
--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -7,6 +7,7 @@ import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/u
 import { Separator } from '@/components/ui/separator';
 import TldInfo from '@/components/TldInfo';
 import { WhoisInfo } from '@/models/whois';
+import { WhoisInfoSection } from '@/components/WhoisInfoSection';
 import { Badge } from '@/components/ui/badge';
 import DomainStatusBadge from '@/components/DomainStatusBadge';
 import DomainRegistrarButtons from '@/components/DomainRegistrarButtons';
@@ -125,28 +126,7 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
 
                     {!domain.isAvailable() && whoisInfo && (
                         <>
-                            <div className="space-y-1">
-                                {whoisInfo.creationDate && (
-                                    <p className="text-xs">
-                                        <span className="font-bold">Created:</span> {whoisInfo.creationDate}
-                                    </p>
-                                )}
-                                {whoisInfo.age && (
-                                    <p className="text-xs">
-                                        <span className="font-bold">Age:</span> {whoisInfo.age}
-                                    </p>
-                                )}
-                                {whoisInfo.expirationDate && (
-                                    <p className="text-xs">
-                                        <span className="font-bold">Expires:</span> {whoisInfo.expirationDate}
-                                    </p>
-                                )}
-                                {whoisInfo.registrar && (
-                                    <p className="text-xs">
-                                        <span className="font-bold">Registrar:</span> {whoisInfo.registrar}
-                                    </p>
-                                )}
-                            </div>
+                            <WhoisInfoSection whoisInfo={whoisInfo} />
                             <Separator />
                         </>
                     )}

--- a/src/components/WhoisInfoSection.test.tsx
+++ b/src/components/WhoisInfoSection.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { WhoisInfoSection } from './WhoisInfoSection';
+import { WhoisInfo } from '@/models/whois';
+
+const info: WhoisInfo = {
+    creationDate: '2000-01-01',
+    age: '24 years',
+    expirationDate: '2030-01-01',
+    registrar: 'Example Registrar',
+};
+
+describe('WhoisInfoSection', () => {
+    it('renders whois fields', () => {
+        render(<WhoisInfoSection whoisInfo={info} />);
+
+        expect(screen.getByText(/Created:/i)).toHaveTextContent('2000-01-01');
+        expect(screen.getByText(/Age:/i)).toHaveTextContent('24 years');
+        expect(screen.getByText(/Expires:/i)).toHaveTextContent('2030-01-01');
+        expect(screen.getByText(/Registrar:/i)).toHaveTextContent('Example Registrar');
+    });
+
+    it('hides empty fields', () => {
+        const partial: WhoisInfo = {
+            creationDate: null,
+            age: null,
+            expirationDate: null,
+            registrar: null,
+        };
+        render(<WhoisInfoSection whoisInfo={partial} />);
+
+        expect(screen.queryByText(/Created:/i)).toBeNull();
+        expect(screen.queryByText(/Age:/i)).toBeNull();
+        expect(screen.queryByText(/Expires:/i)).toBeNull();
+        expect(screen.queryByText(/Registrar:/i)).toBeNull();
+    });
+});
+

--- a/src/components/WhoisInfoSection.tsx
+++ b/src/components/WhoisInfoSection.tsx
@@ -1,0 +1,33 @@
+import { WhoisInfo } from '@/models/whois';
+
+interface WhoisInfoSectionProps {
+    whoisInfo: WhoisInfo;
+}
+
+export function WhoisInfoSection({ whoisInfo }: WhoisInfoSectionProps) {
+    return (
+        <div className="space-y-1">
+            {whoisInfo.creationDate && (
+                <p className="text-xs">
+                    <span className="font-bold">Created:</span> {whoisInfo.creationDate}
+                </p>
+            )}
+            {whoisInfo.age && (
+                <p className="text-xs">
+                    <span className="font-bold">Age:</span> {whoisInfo.age}
+                </p>
+            )}
+            {whoisInfo.expirationDate && (
+                <p className="text-xs">
+                    <span className="font-bold">Expires:</span> {whoisInfo.expirationDate}
+                </p>
+            )}
+            {whoisInfo.registrar && (
+                <p className="text-xs">
+                    <span className="font-bold">Registrar:</span> {whoisInfo.registrar}
+                </p>
+            )}
+        </div>
+    );
+}
+


### PR DESCRIPTION
## Summary
- add `WhoisInfoSection` component to render registrar and date fields
- use new component in `DomainDetailDrawer`
- cover `WhoisInfoSection` with unit tests
- switch `WhoisInfoSection` to a named export and update imports

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898af7ce5bc832bb35f389b756f4ba2