### PR TITLE
Add registrar URL to Whois data

### DIFF
--- a/src/app/api/domains/whois/route.ts
+++ b/src/app/api/domains/whois/route.ts
@@ -27,15 +27,17 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
             creation_date?: string | string[];
             expiration_date?: string | string[];
             registrar?: string;
+            registrar_url?: string;
         };
 
         const result = (response.data as { result?: WhoisResult }).result;
         const creationRaw = result?.creation_date;
         const expirationRaw = result?.expiration_date;
         const registrar = result?.registrar || null;
+        const registrarUrl = result?.registrar_url || null;
         const creationDate = Array.isArray(creationRaw) ? creationRaw[0] : creationRaw || null;
         const expirationDate = Array.isArray(expirationRaw) ? expirationRaw[0] : expirationRaw || null;
-        return NextResponse.json({ creationDate, expirationDate, registrar });
+        return NextResponse.json({ creationDate, expirationDate, registrar, registrarUrl });
     } catch (error) {
         console.error('Error fetching whois data:', error);
         return NextResponse.json({ error: 'Failed to fetch whois data' }, { status: 500 });

--- a/src/components/DomainDetailDrawer.test.tsx
+++ b/src/components/DomainDetailDrawer.test.tsx
@@ -89,6 +89,7 @@ describe('DomainDetailDrawer', () => {
             age: '24 years',
             expirationDate: '2030-01-01',
             registrar: 'Example Registrar',
+            registrarUrl: 'https://example-registrar.com',
         });
 
         render(<DomainDetailDrawer domain={domain} status={domain.getStatus()} open={true} onClose={() => {}} />);
@@ -122,6 +123,7 @@ describe('DomainDetailDrawer', () => {
             age: '24 years',
             expirationDate: '2030-01-01',
             registrar: 'Example Registrar',
+            registrarUrl: 'https://example-registrar.com',
         });
 
         render(<DomainDetailDrawer domain={domain} status={domain.getStatus()} open={true} onClose={() => {}} />);
@@ -151,6 +153,7 @@ describe('DomainDetailDrawer', () => {
             age: '24 years',
             expirationDate: '2030-01-01',
             registrar: 'Example Registrar',
+            registrarUrl: 'https://example-registrar.com',
         });
 
         render(<DomainDetailDrawer domain={domain} status={domain.getStatus()} open={true} onClose={() => {}} />);
@@ -160,6 +163,8 @@ describe('DomainDetailDrawer', () => {
         expect(screen.getByText(/Age:/i)).toHaveTextContent('24 years');
         expect(screen.getByText(/Expires:/i)).toHaveTextContent('2030-01-01');
         expect(screen.getByText(/Registrar:/i)).toHaveTextContent('Example Registrar');
+        const registrarLink = screen.getByRole('link', { name: 'https://example-registrar.com' });
+        expect(registrarLink).toHaveAttribute('href', 'https://example-registrar.com');
 
         expect(mockedApiService.digDomain).toHaveBeenCalledWith(domain.getName(), DNSRecordType.A);
 

--- a/src/components/WhoisInfoSection.test.tsx
+++ b/src/components/WhoisInfoSection.test.tsx
@@ -7,6 +7,7 @@ const info: WhoisInfo = {
     age: '24 years',
     expirationDate: '2030-01-01',
     registrar: 'Example Registrar',
+    registrarUrl: 'https://example-registrar.com',
 };
 
 describe('WhoisInfoSection', () => {
@@ -17,6 +18,8 @@ describe('WhoisInfoSection', () => {
         expect(screen.getByText(/Age:/i)).toHaveTextContent('24 years');
         expect(screen.getByText(/Expires:/i)).toHaveTextContent('2030-01-01');
         expect(screen.getByText(/Registrar:/i)).toHaveTextContent('Example Registrar');
+        const registrarLink = screen.getByRole('link', { name: 'https://example-registrar.com' });
+        expect(registrarLink).toHaveAttribute('href', 'https://example-registrar.com');
     });
 
     it('hides empty fields', () => {
@@ -25,6 +28,7 @@ describe('WhoisInfoSection', () => {
             age: null,
             expirationDate: null,
             registrar: null,
+            registrarUrl: null,
         };
         render(<WhoisInfoSection whoisInfo={partial} />);
 
@@ -32,6 +36,7 @@ describe('WhoisInfoSection', () => {
         expect(screen.queryByText(/Age:/i)).toBeNull();
         expect(screen.queryByText(/Expires:/i)).toBeNull();
         expect(screen.queryByText(/Registrar:/i)).toBeNull();
+        expect(screen.queryByText(/Registrar URL:/i)).toBeNull();
     });
 });
 

--- a/src/components/WhoisInfoSection.tsx
+++ b/src/components/WhoisInfoSection.tsx
@@ -27,6 +27,19 @@ export function WhoisInfoSection({ whoisInfo }: WhoisInfoSectionProps) {
                     <span className="font-bold">Registrar:</span> {whoisInfo.registrar}
                 </p>
             )}
+            {whoisInfo.registrarUrl && (
+                <p className="text-xs">
+                    <span className="font-bold">Registrar URL:</span>{' '}
+                    <a
+                        href={whoisInfo.registrarUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 underline"
+                    >
+                        {whoisInfo.registrarUrl}
+                    </a>
+                </p>
+            )}
         </div>
     );
 }

--- a/src/models/whois.ts
+++ b/src/models/whois.ts
@@ -3,4 +3,5 @@ export interface WhoisInfo {
     age: string | null;
     expirationDate: string | null;
     registrar: string | null;
+    registrarUrl: string | null;
 }


### PR DESCRIPTION
## Summary
- include registrar URL in WhoisInfo model and API response
- show registrar URL in domain detail panel
- update tests for registrar URL display

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898cec0a548832b85f543e0e7be0478