### PR TITLE
Simplify Whois section

### DIFF
--- a/src/components/DomainDetailDrawer.test.tsx
+++ b/src/components/DomainDetailDrawer.test.tsx
@@ -86,7 +86,6 @@ describe('DomainDetailDrawer', () => {
         });
         mockedApiService.getDomainWhois.mockResolvedValue({
             creationDate: '2000-01-01',
-            age: '24 years',
             expirationDate: '2030-01-01',
             registrar: 'Example Registrar',
             registrarUrl: 'https://example-registrar.com',
@@ -120,7 +119,6 @@ describe('DomainDetailDrawer', () => {
         });
         mockedApiService.getDomainWhois.mockResolvedValue({
             creationDate: '2000-01-01',
-            age: '24 years',
             expirationDate: '2030-01-01',
             registrar: 'Example Registrar',
             registrarUrl: 'https://example-registrar.com',
@@ -150,7 +148,6 @@ describe('DomainDetailDrawer', () => {
         });
         mockedApiService.getDomainWhois.mockResolvedValue({
             creationDate: '2000-01-01',
-            age: '24 years',
             expirationDate: '2030-01-01',
             registrar: 'Example Registrar',
             registrarUrl: 'https://example-registrar.com',
@@ -158,12 +155,11 @@ describe('DomainDetailDrawer', () => {
 
         render(<DomainDetailDrawer domain={domain} status={domain.getStatus()} open={true} onClose={() => {}} />);
 
-        await screen.findByText(/Created:/i);
-        expect(screen.getByText(/Created:/i)).toHaveTextContent('2000-01-01');
-        expect(screen.getByText(/Age:/i)).toHaveTextContent('24 years');
-        expect(screen.getByText(/Expires:/i)).toHaveTextContent('2030-01-01');
-        expect(screen.getByText(/Registrar:/i)).toHaveTextContent('Example Registrar');
-        const registrarLink = screen.getByRole('link', { name: 'https://example-registrar.com' });
+        const whoisParagraph = await screen.findByText(/This domain was created on/i);
+        expect(whoisParagraph).toHaveTextContent(
+            'This domain was created on 2000-01-01. It is registered with Example Registrar. It is set to expire on 2030-01-01.',
+        );
+        const registrarLink = screen.getByRole('link', { name: 'Example Registrar' });
         expect(registrarLink).toHaveAttribute('href', 'https://example-registrar.com');
 
         expect(mockedApiService.digDomain).toHaveBeenCalledWith(domain.getName(), DNSRecordType.A);

--- a/src/components/WhoisInfoSection.test.tsx
+++ b/src/components/WhoisInfoSection.test.tsx
@@ -4,39 +4,33 @@ import { WhoisInfo } from '@/models/whois';
 
 const info: WhoisInfo = {
     creationDate: '2000-01-01',
-    age: '24 years',
     expirationDate: '2030-01-01',
     registrar: 'Example Registrar',
     registrarUrl: 'https://example-registrar.com',
 };
 
 describe('WhoisInfoSection', () => {
-    it('renders whois fields', () => {
+    it('renders whois information', () => {
         render(<WhoisInfoSection whoisInfo={info} />);
 
-        expect(screen.getByText(/Created:/i)).toHaveTextContent('2000-01-01');
-        expect(screen.getByText(/Age:/i)).toHaveTextContent('24 years');
-        expect(screen.getByText(/Expires:/i)).toHaveTextContent('2030-01-01');
-        expect(screen.getByText(/Registrar:/i)).toHaveTextContent('Example Registrar');
-        const registrarLink = screen.getByRole('link', { name: 'https://example-registrar.com' });
+        const paragraph = screen.getByText(/This domain was created on/i);
+        expect(paragraph).toHaveTextContent(
+            'This domain was created on 2000-01-01. It is registered with Example Registrar. It is set to expire on 2030-01-01.',
+        );
+        const registrarLink = screen.getByRole('link', { name: 'Example Registrar' });
         expect(registrarLink).toHaveAttribute('href', 'https://example-registrar.com');
     });
 
-    it('hides empty fields', () => {
+    it('returns null when required info is missing', () => {
         const partial: WhoisInfo = {
-            creationDate: null,
-            age: null,
+            creationDate: '2000-01-01',
             expirationDate: null,
-            registrar: null,
-            registrarUrl: null,
+            registrar: 'Example Registrar',
+            registrarUrl: 'https://example-registrar.com',
         };
         render(<WhoisInfoSection whoisInfo={partial} />);
 
-        expect(screen.queryByText(/Created:/i)).toBeNull();
-        expect(screen.queryByText(/Age:/i)).toBeNull();
-        expect(screen.queryByText(/Expires:/i)).toBeNull();
-        expect(screen.queryByText(/Registrar:/i)).toBeNull();
-        expect(screen.queryByText(/Registrar URL:/i)).toBeNull();
+        expect(screen.queryByText(/This domain was created on/i)).toBeNull();
     });
 });
 

--- a/src/components/WhoisInfoSection.tsx
+++ b/src/components/WhoisInfoSection.tsx
@@ -5,42 +5,25 @@ interface WhoisInfoSectionProps {
 }
 
 export function WhoisInfoSection({ whoisInfo }: WhoisInfoSectionProps) {
+    const { creationDate, registrarUrl, registrar, expirationDate } = whoisInfo;
+
+    if (!creationDate || !registrarUrl || !expirationDate) {
+        return null;
+    }
+
     return (
-        <div className="space-y-1">
-            {whoisInfo.creationDate && (
-                <p className="text-xs">
-                    <span className="font-bold">Created:</span> {whoisInfo.creationDate}
-                </p>
-            )}
-            {whoisInfo.age && (
-                <p className="text-xs">
-                    <span className="font-bold">Age:</span> {whoisInfo.age}
-                </p>
-            )}
-            {whoisInfo.expirationDate && (
-                <p className="text-xs">
-                    <span className="font-bold">Expires:</span> {whoisInfo.expirationDate}
-                </p>
-            )}
-            {whoisInfo.registrar && (
-                <p className="text-xs">
-                    <span className="font-bold">Registrar:</span> {whoisInfo.registrar}
-                </p>
-            )}
-            {whoisInfo.registrarUrl && (
-                <p className="text-xs">
-                    <span className="font-bold">Registrar URL:</span>{' '}
-                    <a
-                        href={whoisInfo.registrarUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-blue-600 underline"
-                    >
-                        {whoisInfo.registrarUrl}
-                    </a>
-                </p>
-            )}
-        </div>
+        <p className="text-xs">
+            This domain was created on {creationDate}. It is registered with{' '}
+            <a
+                href={registrarUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 underline"
+            >
+                {registrar ?? registrarUrl}
+            </a>
+            . It is set to expire on {expirationDate}.
+        </p>
     );
 }
 

--- a/src/models/whois.ts
+++ b/src/models/whois.ts
@@ -1,6 +1,5 @@
 export interface WhoisInfo {
     creationDate: string | null;
-    age: string | null;
     expirationDate: string | null;
     registrar: string | null;
     registrarUrl: string | null;


### PR DESCRIPTION
## Summary
- Short-circuit WhoisInfoSection to return early when data is incomplete
- Remove age from Whois display and data requirements

## Testing
- `npm install` *(fails: ERESOLVE could not resolve dependency: react-loader-spinner@6.1.6)*
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898e92864c4832b97c1f6fa542b1cdf