### PR TITLE
Emphasize WHOIS details with bold styling

### DIFF
--- a/src/components/DomainDetailDrawer.test.tsx
+++ b/src/components/DomainDetailDrawer.test.tsx
@@ -161,6 +161,11 @@ describe('DomainDetailDrawer', () => {
         );
         const registrarLink = screen.getByRole('link', { name: 'Example Registrar' });
         expect(registrarLink).toHaveAttribute('href', 'https://example-registrar.com');
+        expect(registrarLink).toHaveClass('font-bold');
+        const creationSpan = screen.getByText('2000-01-01');
+        expect(creationSpan).toHaveClass('font-bold');
+        const expirationSpan = screen.getByText('2030-01-01');
+        expect(expirationSpan).toHaveClass('font-bold');
 
         expect(mockedApiService.digDomain).toHaveBeenCalledWith(domain.getName(), DNSRecordType.A);
 

--- a/src/components/WhoisInfoSection.test.tsx
+++ b/src/components/WhoisInfoSection.test.tsx
@@ -19,6 +19,11 @@ describe('WhoisInfoSection', () => {
         );
         const registrarLink = screen.getByRole('link', { name: 'Example Registrar' });
         expect(registrarLink).toHaveAttribute('href', 'https://example-registrar.com');
+        expect(registrarLink).toHaveClass('font-bold');
+        const creationSpan = screen.getByText('2000-01-01');
+        expect(creationSpan).toHaveClass('font-bold');
+        const expirationSpan = screen.getByText('2030-01-01');
+        expect(expirationSpan).toHaveClass('font-bold');
     });
 
     it('returns null when required info is missing', () => {

--- a/src/components/WhoisInfoSection.tsx
+++ b/src/components/WhoisInfoSection.tsx
@@ -13,16 +13,16 @@ export function WhoisInfoSection({ whoisInfo }: WhoisInfoSectionProps) {
 
     return (
         <p className="text-xs">
-            This domain was created on {creationDate}. It is registered with{' '}
+            This domain was created on <span className="font-bold">{creationDate}</span>. It is registered with{' '}
             <a
                 href={registrarUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-blue-600 underline"
+                className="font-bold text-blue-600 underline"
             >
                 {registrar ?? registrarUrl}
             </a>
-            . It is set to expire on {expirationDate}.
+            . It is set to expire on <span className="font-bold">{expirationDate}</span>.
         </p>
     );
 }


### PR DESCRIPTION
## Summary
- make creation, registrar, and expiration values bold in WHOIS details
- assert bold styling in component tests

## Testing
- `npm run lint` *(fails: next: not found)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898f2dbccfc832ba5af986b408ecb87