### PR TITLE
Format WHOIS dates using date-fns

### DIFF
--- a/src/components/DomainDetailDrawer.test.tsx
+++ b/src/components/DomainDetailDrawer.test.tsx
@@ -85,7 +85,7 @@ describe('DomainDetailDrawer', () => {
             },
         });
         mockedApiService.getDomainWhois.mockResolvedValue({
-            creationDate: '2000-01-01',
+            creationDate: '2025-10-03',
             expirationDate: '2030-01-01',
             registrar: 'Example Registrar',
             registrarUrl: 'https://example-registrar.com',
@@ -118,7 +118,7 @@ describe('DomainDetailDrawer', () => {
             },
         });
         mockedApiService.getDomainWhois.mockResolvedValue({
-            creationDate: '2000-01-01',
+            creationDate: '2025-10-03',
             expirationDate: '2030-01-01',
             registrar: 'Example Registrar',
             registrarUrl: 'https://example-registrar.com',
@@ -147,7 +147,7 @@ describe('DomainDetailDrawer', () => {
             },
         });
         mockedApiService.getDomainWhois.mockResolvedValue({
-            creationDate: '2000-01-01',
+            creationDate: '2025-10-03',
             expirationDate: '2030-01-01',
             registrar: 'Example Registrar',
             registrarUrl: 'https://example-registrar.com',
@@ -157,14 +157,14 @@ describe('DomainDetailDrawer', () => {
 
         const whoisParagraph = await screen.findByText(/This domain was created on/i);
         expect(whoisParagraph).toHaveTextContent(
-            'This domain was created on 2000-01-01. It is registered with Example Registrar. It is set to expire on 2030-01-01.',
+            'This domain was created on October 3rd, 2025. It is registered with Example Registrar. It is set to expire on January 1st, 2030.',
         );
         const registrarLink = screen.getByRole('link', { name: 'Example Registrar' });
         expect(registrarLink).toHaveAttribute('href', 'https://example-registrar.com');
         expect(registrarLink).toHaveClass('font-bold');
-        const creationSpan = screen.getByText('2000-01-01');
+        const creationSpan = screen.getByText('October 3rd, 2025');
         expect(creationSpan).toHaveClass('font-bold');
-        const expirationSpan = screen.getByText('2030-01-01');
+        const expirationSpan = screen.getByText('January 1st, 2030');
         expect(expirationSpan).toHaveClass('font-bold');
 
         expect(mockedApiService.digDomain).toHaveBeenCalledWith(domain.getName(), DNSRecordType.A);

--- a/src/components/WhoisInfoSection.test.tsx
+++ b/src/components/WhoisInfoSection.test.tsx
@@ -3,7 +3,7 @@ import { WhoisInfoSection } from './WhoisInfoSection';
 import { WhoisInfo } from '@/models/whois';
 
 const info: WhoisInfo = {
-    creationDate: '2000-01-01',
+    creationDate: '2025-10-03',
     expirationDate: '2030-01-01',
     registrar: 'Example Registrar',
     registrarUrl: 'https://example-registrar.com',
@@ -15,20 +15,20 @@ describe('WhoisInfoSection', () => {
 
         const paragraph = screen.getByText(/This domain was created on/i);
         expect(paragraph).toHaveTextContent(
-            'This domain was created on 2000-01-01. It is registered with Example Registrar. It is set to expire on 2030-01-01.',
+            'This domain was created on October 3rd, 2025. It is registered with Example Registrar. It is set to expire on January 1st, 2030.',
         );
         const registrarLink = screen.getByRole('link', { name: 'Example Registrar' });
         expect(registrarLink).toHaveAttribute('href', 'https://example-registrar.com');
         expect(registrarLink).toHaveClass('font-bold');
-        const creationSpan = screen.getByText('2000-01-01');
+        const creationSpan = screen.getByText('October 3rd, 2025');
         expect(creationSpan).toHaveClass('font-bold');
-        const expirationSpan = screen.getByText('2030-01-01');
+        const expirationSpan = screen.getByText('January 1st, 2030');
         expect(expirationSpan).toHaveClass('font-bold');
     });
 
     it('returns null when required info is missing', () => {
         const partial: WhoisInfo = {
-            creationDate: '2000-01-01',
+            creationDate: '2025-10-03',
             expirationDate: null,
             registrar: 'Example Registrar',
             registrarUrl: 'https://example-registrar.com',

--- a/src/components/WhoisInfoSection.tsx
+++ b/src/components/WhoisInfoSection.tsx
@@ -1,7 +1,16 @@
 import { WhoisInfo } from '@/models/whois';
+import { format, parseISO } from 'date-fns';
 
 interface WhoisInfoSectionProps {
     whoisInfo: WhoisInfo;
+}
+
+function formatDate(dateStr: string): string {
+    try {
+        return format(parseISO(dateStr), 'MMMM do, yyyy');
+    } catch {
+        return dateStr;
+    }
 }
 
 export function WhoisInfoSection({ whoisInfo }: WhoisInfoSectionProps) {
@@ -11,9 +20,13 @@ export function WhoisInfoSection({ whoisInfo }: WhoisInfoSectionProps) {
         return null;
     }
 
+    const formattedCreationDate = formatDate(creationDate);
+    const formattedExpirationDate = formatDate(expirationDate);
+
     return (
         <p className="text-xs">
-            This domain was created on <span className="font-bold">{creationDate}</span>. It is registered with{' '}
+            This domain was created on <span className="font-bold">{formattedCreationDate}</span>. It is registered
+            with{' '}
             <a
                 href={registrarUrl}
                 target="_blank"
@@ -22,7 +35,7 @@ export function WhoisInfoSection({ whoisInfo }: WhoisInfoSectionProps) {
             >
                 {registrar ?? registrarUrl}
             </a>
-            . It is set to expire on <span className="font-bold">{expirationDate}</span>.
+            . It is set to expire on <span className="font-bold">{formattedExpirationDate}</span>.
         </p>
     );
 }


### PR DESCRIPTION
## Summary
- inline WHOIS date formatter directly in component and drop separate helper file

## Testing
- `npm install --legacy-peer-deps` (fails: command timed out)
- `npm test` (fails: jest: not found)
- `npm run lint` (fails: next: not found)

------
https://chatgpt.com/codex/tasks/task_e_6898f98112e4832b8e293ee487f80d2e