### PR TITLE
refactor: rename TldInfo to TldSection

### DIFF
--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -5,13 +5,13 @@ import { Loader2 } from 'lucide-react';
 import { Domain, DomainStatus as DomainStatusEnum, DOMAIN_STATUS_DESCRIPTIONS } from '@/models/domain';
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
 import { Separator } from '@/components/ui/separator';
-import TldInfo from '@/components/TldInfo';
+import TldSection from '@/components/TldSection';
 import { WhoisInfo } from '@/models/whois';
 import { WhoisInfoSection } from '@/components/WhoisInfoSection';
 import { Badge } from '@/components/ui/badge';
 import DomainStatusBadge from '@/components/DomainStatusBadge';
 import DomainRegistrarButtons from '@/components/DomainRegistrarButtons';
-import { apiService, TldInfo as TldInfoType } from '@/services/api';
+import { apiService, TldInfo } from '@/services/api';
 import { DNSRecordType } from '@/models/dig';
 
 interface DomainDetailDrawerProps {
@@ -24,7 +24,7 @@ interface DomainDetailDrawerProps {
 export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDetailDrawerProps) {
     const [hasARecord, setHasARecord] = useState(false);
     const [whoisInfo, setWhoisInfo] = useState<WhoisInfo | null>(null);
-    const [tldInfo, setTldInfo] = useState<TldInfoType | null>(null);
+    const [tldInfo, setTldInfo] = useState<TldInfo | null>(null);
     const [loading, setLoading] = useState(false);
 
     useEffect(() => {
@@ -55,10 +55,10 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                     }
 
                     setWhoisInfo(whoisData as WhoisInfo);
-                    setTldInfo(tldData as TldInfoType);
+                    setTldInfo(tldData as TldInfo);
                 } else {
                     const tldData = await tldPromise;
-                    setTldInfo(tldData as TldInfoType);
+                    setTldInfo(tldData as TldInfo);
                 }
             } catch (error) {
                 console.error('Error fetching domain details:', error);
@@ -133,7 +133,7 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
 
                     {tldInfo && (
                         <div>
-                            <TldInfo tld={domain.getTLD()} info={tldInfo} />
+                            <TldSection tld={domain.getTLD()} {...tldInfo} />
                         </div>
                     )}
                 </div>

--- a/src/components/TldSection.tsx
+++ b/src/components/TldSection.tsx
@@ -1,18 +1,17 @@
 'use client';
 
-import { TldInfo as TldInfoType } from '@/services/api';
+import { TldInfo } from '@/services/api';
 
-interface TldInfoProps {
+interface TldSectionProps extends TldInfo {
     tld: string;
-    info: TldInfoType;
 }
 
-export default function TldInfo({ tld, info }: TldInfoProps) {
+export default function TldSection({ tld, description, wikipediaUrl }: TldSectionProps) {
     return (
         <p className="text-xs">
-            <span className="font-bold">.{tld}:</span> {info.description}{' '}
+            <span className="font-bold">.{tld}:</span> {description}{' '}
             <a
-                href={info.wikipediaUrl}
+                href={wikipediaUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-blue-600 underline"


### PR DESCRIPTION
## Summary
- rename TldInfo component to TldSection
- pass TLD info fields directly as props

## Testing
- `npm test` *(fails: jest not found)*
- `npm install --legacy-peer-deps` *(fails: could not resolve dependency react-loader-spinner@6.1.6)*

------
https://chatgpt.com/codex/tasks/task_e_68998b4a5fd8832b81c1a1e1a2f2a0d0