### PR TITLE
Let API route handle TLD info errors

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -37,20 +37,12 @@ class ApiService {
     }
 
     async getTldInfo(tld: string): Promise<TldInfo> {
-        try {
-            const response = await this.client.get('/api/tlds/info', { params: { tld } });
-            const data = response.data;
-            return {
-                description: data.description ?? 'No additional information is available for this TLD.',
-                wikipediaUrl: `https://en.wikipedia.org/wiki/.${tld}`,
-            };
-        } catch (error) {
-            console.error('Error fetching TLD info:', error);
-            return {
-                description: 'No additional information is available for this TLD.',
-                wikipediaUrl: `https://en.wikipedia.org/wiki/.${tld}`,
-            };
-        }
+        const response = await this.client.get('/api/tlds/info', { params: { tld } });
+        const data = response.data;
+        return {
+            description: data.description ?? 'No additional information is available for this TLD.',
+            wikipediaUrl: `https://en.wikipedia.org/wiki/.${tld}`,
+        };
     }
 }
 


### PR DESCRIPTION
## Summary
- Let API route handle errors when fetching TLD info by removing catch block from ApiService

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899d9f66818832bad781c6288ae89b7