### PR TITLE
Build Wikipedia URL in UI component

### DIFF
--- a/src/components/DomainDetailDrawer.test.tsx
+++ b/src/components/DomainDetailDrawer.test.tsx
@@ -16,7 +16,7 @@ jest.mock('@/services/api', () => ({
     apiService: {
         digDomain: jest.fn(),
         getDomainWhois: jest.fn(),
-        getTldInfo: jest.fn(() => Promise.resolve({ description: 'Test', wikipediaUrl: 'https://example.com' })),
+        getTldInfo: jest.fn(() => Promise.resolve({ description: 'Test' })),
     },
 }));
 const mockedApiService = apiService as jest.Mocked<typeof apiService>;
@@ -69,7 +69,7 @@ describe('DomainDetailDrawer', () => {
         );
 
         const learnMoreLink = await screen.findByRole('link', { name: /Learn more on Wikipedia/i });
-        expect(learnMoreLink).toHaveAttribute('href', 'https://example.com');
+        expect(learnMoreLink).toHaveAttribute('href', `https://en.wikipedia.org/wiki/.${domain.getTLD()}`);
 
         openSpy.mockRestore();
     });

--- a/src/components/TldSection.tsx
+++ b/src/components/TldSection.tsx
@@ -6,7 +6,8 @@ interface TldSectionProps extends TldInfo {
     tld: string;
 }
 
-export default function TldSection({ tld, description, wikipediaUrl }: TldSectionProps) {
+export default function TldSection({ tld, description }: TldSectionProps) {
+    const wikipediaUrl = `https://en.wikipedia.org/wiki/.${tld}`;
     return (
         <p className="text-xs">
             <span className="font-bold">.{tld}:</span> {description}{' '}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -5,7 +5,6 @@ import { WhoisInfo } from '@/models/whois';
 
 export interface TldInfo {
     description: string;
-    wikipediaUrl: string;
 }
 
 class ApiService {
@@ -41,7 +40,6 @@ class ApiService {
         const data = response.data;
         return {
             description: data.description ?? 'No additional information is available for this TLD.',
-            wikipediaUrl: `https://en.wikipedia.org/wiki/.${tld}`,
         };
     }
 }


### PR DESCRIPTION
## Summary
- stop returning the wikipedia URL from ApiService
- build the wikipedia URL within TldSection instead
- update tests to expect the new URL

## Testing
- `npm test` *(fails: jest not found)*
- `npx jest` *(fails: npm error 403)*

------
https://chatgpt.com/codex/tasks/task_e_689af27bd33c832b8527b027f5a64a22