### PR TITLE
refactor: centralize TLD model

### DIFF
--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -11,7 +11,8 @@ import { WhoisInfoSection } from '@/components/WhoisInfoSection';
 import { Badge } from '@/components/ui/badge';
 import DomainStatusBadge from '@/components/DomainStatusBadge';
 import DomainRegistrarButtons from '@/components/DomainRegistrarButtons';
-import { apiService, TldInfo } from '@/services/api';
+import { apiService } from '@/services/api';
+import { TldInfo } from '@/models/tld';
 import { DNSRecordType } from '@/models/dig';
 
 interface DomainDetailDrawerProps {

--- a/src/components/TldSection.tsx
+++ b/src/components/TldSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { TldInfo } from '@/services/api';
+import { TldInfo } from '@/models/tld';
 
 interface TldSectionProps extends TldInfo {
     tld: string;

--- a/src/models/tld.ts
+++ b/src/models/tld.ts
@@ -1,0 +1,3 @@
+export interface TldInfo {
+    description: string;
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,10 +2,7 @@ import axios, { AxiosInstance } from 'axios';
 import { DomainStatus as DomainStatusEnum } from '@/models/domain';
 import { DigInfo, DNSRecordType } from '@/models/dig';
 import { WhoisInfo } from '@/models/whois';
-
-export interface TldInfo {
-    description: string;
-}
+import { TldInfo } from '@/models/tld';
 
 class ApiService {
     private client: AxiosInstance;


### PR DESCRIPTION
## Summary
- move TLDInfo interface into dedicated model file
- update API service and components to use new model

## Testing
- `npm install --force` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-dom)*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c478a59c8832b94bb53ad3adf11ba