### PR TITLE
refactor: simplify domain status badge

### DIFF
--- a/src/components/DomainStatusBadge.tsx
+++ b/src/components/DomainStatusBadge.tsx
@@ -11,37 +11,59 @@ interface DomainStatusBadgeProps {
     className?: string;
 }
 
-export function DomainStatusBadge({ domain, status, className }: DomainStatusBadgeProps) {
+const baseClasses = 'inline-flex h-7 min-w-[6rem] items-center justify-center px-3';
+
+function UnknownBadge({ className }: { className?: string }) {
     return (
-        <Badge
-            className={cn(
-                'inline-flex h-7 min-w-[6rem] items-center justify-center px-3',
-                status === DomainStatusEnum.unknown
-                    ? 'bg-gray-400'
-                    : status === DomainStatusEnum.error
-                      ? 'bg-yellow-400 hover:bg-yellow-500'
-                      : domain.isAvailable()
-                        ? 'bg-green-400 hover:bg-green-600'
-                        : 'bg-red-400 hover:bg-red-600',
-                className,
-            )}
-        >
-            {status === DomainStatusEnum.unknown ? (
-                <div className="flex items-center gap-2">
-                    <Loader2 className="h-4 w-4 animate-spin text-white" />
-                </div>
-            ) : status === DomainStatusEnum.error ? (
-                <div className="flex items-center gap-2">
-                    <AlertCircle className="h-4 w-4 text-white" />
-                    <span>Error</span>
-                </div>
-            ) : domain.isAvailable() ? (
-                'Available'
-            ) : (
-                'Taken'
-            )}
+        <Badge className={cn(baseClasses, 'bg-gray-400', className)}>
+            <div className="flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin text-white" />
+            </div>
         </Badge>
     );
+}
+
+function ErrorBadge({ className }: { className?: string }) {
+    return (
+        <Badge className={cn(baseClasses, 'bg-yellow-400 hover:bg-yellow-500', className)}>
+            <div className="flex items-center gap-2">
+                <AlertCircle className="h-4 w-4 text-white" />
+                <span>Error</span>
+            </div>
+        </Badge>
+    );
+}
+
+function AvailableBadge({ className }: { className?: string }) {
+    return (
+        <Badge className={cn(baseClasses, 'bg-green-400 hover:bg-green-600', className)}>
+            Available
+        </Badge>
+    );
+}
+
+function TakenBadge({ className }: { className?: string }) {
+    return (
+        <Badge className={cn(baseClasses, 'bg-red-400 hover:bg-red-600', className)}>
+            Taken
+        </Badge>
+    );
+}
+
+export function DomainStatusBadge({ domain, status, className }: DomainStatusBadgeProps) {
+    if (status === DomainStatusEnum.unknown) {
+        return <UnknownBadge className={className} />;
+    }
+
+    if (status === DomainStatusEnum.error) {
+        return <ErrorBadge className={className} />;
+    }
+
+    if (domain.isAvailable()) {
+        return <AvailableBadge className={className} />;
+    }
+
+    return <TakenBadge className={className} />;
 }
 
 export default DomainStatusBadge;


### PR DESCRIPTION
## Summary
- split DomainStatusBadge variants into dedicated subcomponents and return the correct one for each status

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: could not resolve dependency react-loader-spinner@6.1.6)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c2869d18832b9e84e63a20d51dee