### PR TITLE
Move TLD description default to UI component

### DIFF
--- a/src/app/api/tlds/info/route.ts
+++ b/src/app/api/tlds/info/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import axios from 'axios';
 
 const WIKIPEDIA_SUMMARY_URL = 'https://en.wikipedia.org/api/rest_v1/page/summary';
-const FALLBACK_DESCRIPTION = 'No additional information is available for this TLD.';
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
     const tld = request.nextUrl.searchParams.get('tld');
@@ -15,7 +14,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         const response = await axios.get(url);
         const extract: string | undefined = response.data?.extract;
         if (!extract) {
-            return NextResponse.json({ description: FALLBACK_DESCRIPTION });
+            return NextResponse.json({});
         }
         const description = extract
             .split(/(?<=\.)\s+/)
@@ -24,6 +23,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         return NextResponse.json({ description });
     } catch (error) {
         console.error('Error fetching TLD info:', error);
-        return NextResponse.json({ description: FALLBACK_DESCRIPTION });
+        return NextResponse.json({});
     }
 }

--- a/src/components/TldSection.test.tsx
+++ b/src/components/TldSection.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import TldSection from './TldSection';
+
+describe('TldSection', () => {
+    it('displays provided description', () => {
+        render(<TldSection tld="com" description="Commercial" />);
+        expect(screen.getByText(/Commercial/)).toBeInTheDocument();
+    });
+
+    it('uses default description when none is provided', () => {
+        render(<TldSection tld="xyz" />);
+        expect(
+            screen.getByText('No additional information is available for this TLD.'),
+        ).toBeInTheDocument();
+    });
+});

--- a/src/components/TldSection.tsx
+++ b/src/components/TldSection.tsx
@@ -8,9 +8,10 @@ interface TldSectionProps extends TldInfo {
 
 export default function TldSection({ tld, description }: TldSectionProps) {
     const wikipediaUrl = `https://en.wikipedia.org/wiki/.${tld}`;
+    const tldDescription = description ?? 'No additional information is available for this TLD.';
     return (
         <p className="text-xs">
-            <span className="font-bold">.{tld}:</span> {description}{' '}
+            <span className="font-bold">.{tld}:</span> {tldDescription}{' '}
             <a
                 href={wikipediaUrl}
                 target="_blank"

--- a/src/models/tld.ts
+++ b/src/models/tld.ts
@@ -1,3 +1,3 @@
 export interface TldInfo {
-    description: string;
+    description?: string;
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -36,7 +36,7 @@ class ApiService {
         const response = await this.client.get('/api/tlds/info', { params: { tld } });
         const data = response.data;
         return {
-            description: data.description ?? 'No additional information is available for this TLD.',
+            description: data.description,
         };
     }
 }


### PR DESCRIPTION
## Summary
- let `ApiService` return raw TLD descriptions without fallback
- show fallback description inside `TldSection`
- remove server-side default and cover new behavior with a test

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cf852d38832bbe686b226ce78eec