### PR TITLE
feat(api): use path for domain status

### DIFF
--- a/src/app/api/domain/[domain]/status/route.ts
+++ b/src/app/api/domain/[domain]/status/route.ts
@@ -4,12 +4,15 @@ import axios from 'axios';
 const DOMAINR_BASE_URL = 'https://domainr.p.rapidapi.com/v2/status';
 const RAPID_API_KEY = process.env.RAPID_API_KEY!;
 
-export async function GET(request: NextRequest): Promise<NextResponse> {
+export async function GET(
+    _request: NextRequest,
+    { params }: { params: { domain: string } },
+): Promise<NextResponse> {
     try {
-        const domain = request.nextUrl.searchParams.get('domain');
-        const params = { domain: domain! };
+        const { domain } = params;
+        const query = { domain };
         const headers = { headers: { 'x-rapidapi-key': RAPID_API_KEY } };
-        const url = `${DOMAINR_BASE_URL}?${new URLSearchParams(params).toString()}`;
+        const url = `${DOMAINR_BASE_URL}?${new URLSearchParams(query).toString()}`;
         const response = await axios.get(url, headers);
         return NextResponse.json(response.data);
     } catch (error) {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -17,7 +17,7 @@ class ApiService {
     }
 
     async getDomainStatus(domain: string): Promise<DomainStatusEnum> {
-        const response = await this.client.get('/api/domains/status', { params: { domain } });
+        const response = await this.client.get(`/api/domain/${domain}/status`);
         const data = response.data as { status?: { summary?: string }[] };
         return (data.status?.[0]?.summary as DomainStatusEnum) ?? DomainStatusEnum.error;
     }


### PR DESCRIPTION
## Summary
- expose domain status under `/api/domain/<name>/status` with path parameter
- fetch domain status via new endpoint

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install jest --legacy-peer-deps` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ec4a00d8832b81427a37e38f0356