### PR TITLE
feat(api): use path for domain status

### DIFF
--- a/src/app/api/domain/[domain]/dig/route.ts
+++ b/src/app/api/domain/[domain]/dig/route.ts
@@ -4,13 +4,12 @@ import { DNSRecordType } from '@/models/dig';
 
 const resolver = new Resolver();
 
-export async function GET(request: NextRequest): Promise<NextResponse> {
-    const domain = request.nextUrl.searchParams.get('domain');
+export async function GET(
+    request: NextRequest,
+    { params }: { params: { domain: string } },
+): Promise<NextResponse> {
+    const { domain } = params;
     const recordTypeParam = request.nextUrl.searchParams.get('type')?.toUpperCase();
-
-    if (!domain) {
-        return NextResponse.json({ error: 'Missing domain parameter' }, { status: 400 });
-    }
 
     if (!recordTypeParam) {
         return NextResponse.json({ error: 'Missing type parameter' }, { status: 400 });

--- a/src/app/api/domain/[domain]/status/route.ts
+++ b/src/app/api/domain/[domain]/status/route.ts
@@ -4,12 +4,15 @@ import axios from 'axios';
 const DOMAINR_BASE_URL = 'https://domainr.p.rapidapi.com/v2/status';
 const RAPID_API_KEY = process.env.RAPID_API_KEY!;
 
-export async function GET(request: NextRequest): Promise<NextResponse> {
+export async function GET(
+    _request: NextRequest,
+    { params }: { params: { domain: string } },
+): Promise<NextResponse> {
     try {
-        const domain = request.nextUrl.searchParams.get('domain');
-        const params = { domain: domain! };
+        const { domain } = params;
+        const query = { domain };
         const headers = { headers: { 'x-rapidapi-key': RAPID_API_KEY } };
-        const url = `${DOMAINR_BASE_URL}?${new URLSearchParams(params).toString()}`;
+        const url = `${DOMAINR_BASE_URL}?${new URLSearchParams(query).toString()}`;
         const response = await axios.get(url, headers);
         return NextResponse.json(response.data);
     } catch (error) {

--- a/src/app/api/domain/[domain]/whois/route.ts
+++ b/src/app/api/domain/[domain]/whois/route.ts
@@ -5,11 +5,11 @@ const WHOIS_URL = 'https://whois-api6.p.rapidapi.com/whois/api/v1/getData';
 const WHOIS_HOST = 'whois-api6.p.rapidapi.com';
 const RAPID_API_KEY = process.env.RAPID_API_KEY!;
 
-export async function GET(request: NextRequest): Promise<NextResponse> {
-    const domain = request.nextUrl.searchParams.get('domain');
-    if (!domain) {
-        return NextResponse.json({ error: 'Missing domain parameter' }, { status: 400 });
-    }
+export async function GET(
+    _request: NextRequest,
+    { params }: { params: { domain: string } },
+): Promise<NextResponse> {
+    const { domain } = params;
 
     try {
         const response = await axios.post(

--- a/src/app/api/tld/[tld]/info/route.ts
+++ b/src/app/api/tld/[tld]/info/route.ts
@@ -3,11 +3,11 @@ import axios from 'axios';
 
 const WIKIPEDIA_SUMMARY_URL = 'https://en.wikipedia.org/api/rest_v1/page/summary';
 
-export async function GET(request: NextRequest): Promise<NextResponse> {
-    const tld = request.nextUrl.searchParams.get('tld');
-    if (!tld) {
-        return NextResponse.json({ error: 'Missing tld parameter' }, { status: 400 });
-    }
+export async function GET(
+    _request: NextRequest,
+    { params }: { params: { tld: string } },
+): Promise<NextResponse> {
+    const { tld } = params;
 
     try {
         const url = `${WIKIPEDIA_SUMMARY_URL}/.${tld}`;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -17,23 +17,23 @@ class ApiService {
     }
 
     async getDomainStatus(domain: string): Promise<DomainStatusEnum> {
-        const response = await this.client.get('/api/domains/status', { params: { domain } });
+        const response = await this.client.get(`/api/domain/${domain}/status`);
         const data = response.data as { status?: { summary?: string }[] };
         return (data.status?.[0]?.summary as DomainStatusEnum) ?? DomainStatusEnum.error;
     }
 
     async getDomainWhois(domain: string): Promise<WhoisInfo> {
-        const response = await this.client.get('/api/domains/whois', { params: { domain } });
+        const response = await this.client.get(`/api/domain/${domain}/whois`);
         return response.data as WhoisInfo;
     }
 
     async digDomain(domain: string, type: DNSRecordType): Promise<DigInfo> {
-        const response = await this.client.get('/api/domains/dig', { params: { domain, type } });
+        const response = await this.client.get(`/api/domain/${domain}/dig`, { params: { type } });
         return response.data as DigInfo;
     }
 
     async getTldInfo(tld: string): Promise<TldInfo> {
-        const response = await this.client.get('/api/tlds/info', { params: { tld } });
+        const response = await this.client.get(`/api/tld/${tld}/info`);
         const data = response.data;
         return { description: data.description };
     }


### PR DESCRIPTION
## Summary
- expose whois and dig under `/api/domain/<name>/whois` and `/api/domain/<name>/dig`
- expose tld info under `/api/tld/<tld>/info`
- fetch whois, dig, and tld info via new endpoints

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install jest --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ec4a00d8832b81427a37e38f0356