### PR TITLE
Unify API routes under domains/[name]

### DIFF
--- a/src/app/api/domains/[name]/dig/route.ts
+++ b/src/app/api/domains/[name]/dig/route.ts
@@ -6,9 +6,9 @@ const resolver = new Resolver();
 
 export async function GET(
     request: NextRequest,
-    { params }: { params: { domain: string } },
+    { params }: { params: { name: string } },
 ): Promise<NextResponse> {
-    const { domain } = params;
+    const { name: domain } = params;
     const recordTypeParam = request.nextUrl.searchParams.get('type')?.toUpperCase();
 
     if (!recordTypeParam) {

--- a/src/app/api/domains/[name]/info/route.ts
+++ b/src/app/api/domains/[name]/info/route.ts
@@ -5,9 +5,9 @@ const WIKIPEDIA_SUMMARY_URL = 'https://en.wikipedia.org/api/rest_v1/page/summary
 
 export async function GET(
     _request: NextRequest,
-    { params }: { params: { tld: string } },
+    { params }: { params: { name: string } },
 ): Promise<NextResponse> {
-    const { tld } = params;
+    const { name: tld } = params;
 
     try {
         const url = `${WIKIPEDIA_SUMMARY_URL}/.${tld}`;

--- a/src/app/api/domains/[name]/status/route.ts
+++ b/src/app/api/domains/[name]/status/route.ts
@@ -6,10 +6,10 @@ const RAPID_API_KEY = process.env.RAPID_API_KEY!;
 
 export async function GET(
     _request: NextRequest,
-    { params }: { params: { domain: string } },
+    { params }: { params: { name: string } },
 ): Promise<NextResponse> {
     try {
-        const { domain } = params;
+        const { name: domain } = params;
         const query = { domain };
         const headers = { headers: { 'x-rapidapi-key': RAPID_API_KEY } };
         const url = `${DOMAINR_BASE_URL}?${new URLSearchParams(query).toString()}`;

--- a/src/app/api/domains/[name]/whois/route.ts
+++ b/src/app/api/domains/[name]/whois/route.ts
@@ -7,9 +7,9 @@ const RAPID_API_KEY = process.env.RAPID_API_KEY!;
 
 export async function GET(
     _request: NextRequest,
-    { params }: { params: { domain: string } },
+    { params }: { params: { name: string } },
 ): Promise<NextResponse> {
-    const { domain } = params;
+    const { name: domain } = params;
 
     try {
         const response = await axios.post(

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -17,23 +17,23 @@ class ApiService {
     }
 
     async getDomainStatus(domain: string): Promise<DomainStatusEnum> {
-        const response = await this.client.get(`/api/domain/${domain}/status`);
+        const response = await this.client.get(`/api/domains/${domain}/status`);
         const data = response.data as { status?: { summary?: string }[] };
         return (data.status?.[0]?.summary as DomainStatusEnum) ?? DomainStatusEnum.error;
     }
 
     async getDomainWhois(domain: string): Promise<WhoisInfo> {
-        const response = await this.client.get(`/api/domain/${domain}/whois`);
+        const response = await this.client.get(`/api/domains/${domain}/whois`);
         return response.data as WhoisInfo;
     }
 
     async digDomain(domain: string, type: DNSRecordType): Promise<DigInfo> {
-        const response = await this.client.get(`/api/domain/${domain}/dig`, { params: { type } });
+        const response = await this.client.get(`/api/domains/${domain}/dig`, { params: { type } });
         return response.data as DigInfo;
     }
 
     async getTldInfo(tld: string): Promise<TldInfo> {
-        const response = await this.client.get(`/api/tld/${tld}/info`);
+        const response = await this.client.get(`/api/domains/${tld}/info`);
         const data = response.data;
         return { description: data.description };
     }


### PR DESCRIPTION
## Summary
- rename API endpoints to use `/api/domains/[name]` paths
- update API service to call new `domains` endpoints

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*
- `npm ci` *(fails: peer dependency conflict with react-loader-spinner)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f58bd8a0832bb37b1bf573eb2ed5