### PR TITLE
Use standard Request context in API routes

### DIFF
--- a/src/app/api/domains/[name]/dig/route.ts
+++ b/src/app/api/domains/[name]/dig/route.ts
@@ -1,15 +1,15 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { Resolver } from 'dns/promises';
 import { DNSRecordType } from '@/models/dig';
 
 const resolver = new Resolver();
 
 export async function GET(
-    request: NextRequest,
-    { params }: { params: { name: string } },
+    request: Request,
+    context: { params: { name: string } },
 ): Promise<NextResponse> {
-    const { name: domain } = params;
-    const recordTypeParam = request.nextUrl.searchParams.get('type')?.toUpperCase();
+    const { name: domain } = context.params;
+    const recordTypeParam = new URL(request.url).searchParams.get('type')?.toUpperCase();
 
     if (!recordTypeParam) {
         return NextResponse.json({ error: 'Missing type parameter' }, { status: 400 });

--- a/src/app/api/domains/[name]/info/route.ts
+++ b/src/app/api/domains/[name]/info/route.ts
@@ -1,13 +1,13 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import axios from 'axios';
 
 const WIKIPEDIA_SUMMARY_URL = 'https://en.wikipedia.org/api/rest_v1/page/summary';
 
 export async function GET(
-    _request: NextRequest,
-    { params }: { params: { name: string } },
+    _request: Request,
+    context: { params: { name: string } },
 ): Promise<NextResponse> {
-    const { name: tld } = params;
+    const { name: tld } = context.params;
 
     try {
         const url = `${WIKIPEDIA_SUMMARY_URL}/.${tld}`;

--- a/src/app/api/domains/[name]/status/route.ts
+++ b/src/app/api/domains/[name]/status/route.ts
@@ -1,15 +1,15 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import axios from 'axios';
 
 const DOMAINR_BASE_URL = 'https://domainr.p.rapidapi.com/v2/status';
 const RAPID_API_KEY = process.env.RAPID_API_KEY!;
 
 export async function GET(
-    _request: NextRequest,
-    { params }: { params: { name: string } },
+    _request: Request,
+    context: { params: { name: string } },
 ): Promise<NextResponse> {
     try {
-        const { name: domain } = params;
+        const { name: domain } = context.params;
         const query = { domain };
         const headers = { headers: { 'x-rapidapi-key': RAPID_API_KEY } };
         const url = `${DOMAINR_BASE_URL}?${new URLSearchParams(query).toString()}`;

--- a/src/app/api/domains/[name]/whois/route.ts
+++ b/src/app/api/domains/[name]/whois/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import axios from 'axios';
 
 const WHOIS_URL = 'https://whois-api6.p.rapidapi.com/whois/api/v1/getData';
@@ -6,10 +6,10 @@ const WHOIS_HOST = 'whois-api6.p.rapidapi.com';
 const RAPID_API_KEY = process.env.RAPID_API_KEY!;
 
 export async function GET(
-    _request: NextRequest,
-    { params }: { params: { name: string } },
+    _request: Request,
+    context: { params: { name: string } },
 ): Promise<NextResponse> {
-    const { name: domain } = params;
+    const { name: domain } = context.params;
 
     try {
         const response = await axios.post(

--- a/src/app/api/domains/search/route.ts
+++ b/src/app/api/domains/search/route.ts
@@ -1,7 +1,8 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { getDomainsHacks } from '@/services/domains';
 
-export async function GET(request: NextRequest): Promise<NextResponse> {
-    const domains = getDomainsHacks(request.nextUrl.searchParams.get('term') || '');
+export async function GET(request: Request): Promise<NextResponse> {
+    const url = new URL(request.url);
+    const domains = getDomainsHacks(url.searchParams.get('term') || '');
     return NextResponse.json({ domains });
 }


### PR DESCRIPTION
## Summary
- align domain API route handlers with Next.js expectations by using the standard `Request` object and passing context via `{ params }`
- update handlers to parse query strings using `URL`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'stack-utils')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a20bc9d348832b9b829b21d8f4a089