### PR TITLE
refactor dig handler params

### DIFF
--- a/src/app/api/domains/[name]/dig/route.ts
+++ b/src/app/api/domains/[name]/dig/route.ts
@@ -6,9 +6,9 @@ const resolver = new Resolver();
 
 export async function GET(
     request: Request,
-    context: { params: { name: string } },
+    { params }: { params: { name: string } },
 ): Promise<NextResponse> {
-    const { name: domain } = context.params;
+    const { name: domain } = params;
     const recordTypeParam = new URL(request.url).searchParams.get('type')?.toUpperCase();
 
     if (!recordTypeParam) {


### PR DESCRIPTION
## Summary
- fix `GET` route handler signature to destructure params for domain dig API

## Testing
- `npm test` *(fails: jest: not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find name 'describe' and other modules)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a214b7a398832b8c71e1c93407f882