### PR TITLE
refactor: simplify dig info interface

### DIFF
--- a/src/app/api/domains/[name]/dig/route.ts
+++ b/src/app/api/domains/[name]/dig/route.ts
@@ -53,7 +53,7 @@ export async function GET(
                 records = Array.isArray(res) ? res.map(String) : [];
             }
         }
-        return NextResponse.json({ result: { domain, type: recordType, records } });
+        return NextResponse.json({ records: { [recordType]: records } });
     } catch {
         return NextResponse.json({ error: 'Failed to fetch DNS data' }, { status: 502 });
     }

--- a/src/components/DomainDetailDrawer.test.tsx
+++ b/src/components/DomainDetailDrawer.test.tsx
@@ -78,10 +78,7 @@ describe('DomainDetailDrawer', () => {
         domain.setStatus(DomainStatus.active);
 
         mockedApiService.digDomain.mockResolvedValue({
-            result: {
-                domain: 'example.com',
-                records: { [DNSRecordType.A]: ['1.2.3.4'] },
-            },
+            records: { [DNSRecordType.A]: ['1.2.3.4'] },
         });
         mockedApiService.getDomainWhois.mockResolvedValue({
             creationDate: '2025-10-03',
@@ -111,10 +108,7 @@ describe('DomainDetailDrawer', () => {
         domain.setStatus(DomainStatus.active);
 
         mockedApiService.digDomain.mockResolvedValue({
-            result: {
-                domain: 'example.com',
-                records: { [DNSRecordType.CNAME]: ['alias.example.com.'] },
-            },
+            records: { [DNSRecordType.CNAME]: ['alias.example.com.'] },
         });
         mockedApiService.getDomainWhois.mockResolvedValue({
             creationDate: '2025-10-03',
@@ -138,10 +132,7 @@ describe('DomainDetailDrawer', () => {
         domain.setStatus(DomainStatus.active);
 
         mockedApiService.digDomain.mockResolvedValue({
-            result: {
-                domain: 'example.com',
-                records: { [DNSRecordType.A]: ['1.2.3.4'] },
-            },
+            records: { [DNSRecordType.A]: ['1.2.3.4'] },
         });
         mockedApiService.getDomainWhois.mockResolvedValue({
             creationDate: '2025-10-03',

--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -48,7 +48,7 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                         tldPromise,
                     ]);
 
-                    if (digData.result.records[DNSRecordType.A]?.length) {
+                    if (digData.records[DNSRecordType.A]?.length) {
                         setHasARecord(true);
                     } else {
                         setHasARecord(false);

--- a/src/models/dig.ts
+++ b/src/models/dig.ts
@@ -8,8 +8,5 @@ export enum DNSRecordType {
 }
 
 export interface DigInfo {
-    result: {
-        domain: string;
-        records: Partial<Record<DNSRecordType, string[]>>;
-    };
+    records: Partial<Record<DNSRecordType, string[]>>;
 }


### PR DESCRIPTION
## Summary
- simplify `DigInfo` interface to only expose DNS records
- adapt domain detail drawer and tests to new dig info shape
- streamline dig API route to return records mapping

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab818f2100832b80445e02b1bf4835