### PR TITLE
Reorder ApiService methods and add unit tests

### DIFF
--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -1,0 +1,87 @@
+import axios from 'axios';
+import { ApiService } from '@/services/api';
+import { DomainStatus as DomainStatusEnum } from '@/models/domain';
+import { DNSRecordType, DigInfo } from '@/models/dig';
+import { WhoisInfo } from '@/models/whois';
+import { TldInfo } from '@/models/tld';
+
+jest.mock('axios');
+
+describe('ApiService', () => {
+    let apiService: ApiService;
+    let getMock: jest.Mock;
+    const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+    beforeEach(() => {
+        getMock = jest.fn();
+        mockedAxios.create.mockReturnValue({ get: getMock } as any);
+        apiService = new ApiService();
+    });
+
+    it('digDomain fetches dig info', async () => {
+        const digInfo: DigInfo = { records: { [DNSRecordType.A]: ['1.1.1.1'] } };
+        getMock.mockResolvedValue({ data: digInfo });
+
+        const result = await apiService.digDomain('example.com', DNSRecordType.A);
+
+        expect(getMock).toHaveBeenCalledWith('/api/domains/example.com/dig', {
+            params: { type: DNSRecordType.A },
+        });
+        expect(result).toEqual(digInfo);
+    });
+
+    it('getDomainStatus fetches domain status', async () => {
+        getMock.mockResolvedValue({
+            data: { status: [{ summary: DomainStatusEnum.active }] },
+        });
+
+        const result = await apiService.getDomainStatus('example.com');
+
+        expect(getMock).toHaveBeenCalledWith('/api/domains/example.com/status');
+        expect(result).toBe(DomainStatusEnum.active);
+    });
+
+    it('getDomainStatus returns error when summary missing', async () => {
+        getMock.mockResolvedValue({ data: { status: [{}] } });
+
+        const result = await apiService.getDomainStatus('example.com');
+
+        expect(result).toBe(DomainStatusEnum.error);
+    });
+
+    it('getDomainWhois fetches whois info', async () => {
+        const whoisInfo: WhoisInfo = {
+            creationDate: '2020-01-01',
+            expirationDate: '2025-01-01',
+            registrar: 'Example',
+            registrarUrl: 'http://example.com',
+        };
+        getMock.mockResolvedValue({ data: whoisInfo });
+
+        const result = await apiService.getDomainWhois('example.com');
+
+        expect(getMock).toHaveBeenCalledWith('/api/domains/example.com/whois');
+        expect(result).toEqual(whoisInfo);
+    });
+
+    it('getTldInfo fetches tld info', async () => {
+        const tldInfo: TldInfo = { description: 'desc' };
+        getMock.mockResolvedValue({ data: tldInfo });
+
+        const result = await apiService.getTldInfo('example.com');
+
+        expect(getMock).toHaveBeenCalledWith('/api/domains/example.com/tld');
+        expect(result).toEqual(tldInfo);
+    });
+
+    it('searchDomains fetches matching domains', async () => {
+        getMock.mockResolvedValue({ data: { domains: ['example.com'] } });
+
+        const result = await apiService.searchDomains('example');
+
+        expect(getMock).toHaveBeenCalledWith('/api/domains/search', {
+            params: { term: 'example' },
+        });
+        expect(result).toEqual(['example.com']);
+    });
+});

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -11,9 +11,9 @@ class ApiService {
         this.client = axios.create();
     }
 
-    async searchDomains(term: string): Promise<string[]> {
-        const response = await this.client.get('/api/domains/search', { params: { term } });
-        return response.data.domains ?? [];
+    async digDomain(domain: string, type: DNSRecordType): Promise<DigInfo> {
+        const response = await this.client.get(`/api/domains/${domain}/dig`, { params: { type } });
+        return response.data as DigInfo;
     }
 
     async getDomainStatus(domain: string): Promise<DomainStatusEnum> {
@@ -27,14 +27,14 @@ class ApiService {
         return response.data as WhoisInfo;
     }
 
-    async digDomain(domain: string, type: DNSRecordType): Promise<DigInfo> {
-        const response = await this.client.get(`/api/domains/${domain}/dig`, { params: { type } });
-        return response.data as DigInfo;
-    }
-
     async getTldInfo(domain: string): Promise<TldInfo> {
         const response = await this.client.get(`/api/domains/${domain}/tld`);
         return response.data as TldInfo;
+    }
+
+    async searchDomains(term: string): Promise<string[]> {
+        const response = await this.client.get('/api/domains/search', { params: { term } });
+        return response.data.domains ?? [];
     }
 }
 


### PR DESCRIPTION
## Summary
- Sort `ApiService` methods alphabetically
- Add Jest unit tests for all `ApiService` methods

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac01d0a3dc832babd0313764bbfede