### PR TITLE
feat: add optional TLD type model

### DIFF
--- a/src/models/tld.ts
+++ b/src/models/tld.ts
@@ -1,3 +1,21 @@
+export enum TldType {
+    // .arpa for technical network infrastructure.
+    INFRASTRUCTURE = 'INFRASTRUCTURE',
+    // Generic domains not tied to a country (e.g., .com, .app).
+    GENERIC = 'GENERIC',
+    // Community-specific domains run by sponsors (e.g., .aero).
+    SPONSORED = 'SPONSORED',
+    // Two-letter country codes (e.g., .uk).
+    COUNTRY_CODE = 'COUNTRY_CODE',
+    // Country codes in local scripts (e.g., .中国).
+    IDN_COUNTRY_CODE = 'IDN_COUNTRY_CODE',
+    // Generic domains in non-Latin scripts (e.g., .みんな).
+    IDN_GENERIC = 'IDN_GENERIC',
+    // Reserved or special-use domains for testing (e.g., .test).
+    TEST = 'TEST',
+}
+
 export interface TldInfo {
     description?: string;
+    type?: TldType;
 }


### PR DESCRIPTION
## Summary
- add `TldType` enum with optional `type` property on TLD model
- align `TldType` values and examples with IANA's TLD classifications, including a new `SPONSORED` category

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden when fetching react-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68acf1623b1c832b8529f70fe36209bb