### PR TITLE
refactor dns record resolution

### DIFF
--- a/src/app/api/domains/[name]/dig/route.ts
+++ b/src/app/api/domains/[name]/dig/route.ts
@@ -15,43 +15,20 @@ export async function GET(
         if (!recordTypeParam || !Object.values(DNSRecordType).includes(recordTypeParam as DNSRecordType)) {
             return NextResponse.json({ error: `Invalid record type: ${recordTypeParam}` }, { status: 400 });
         }
-        let records: string[] = [];
         const recordType = recordTypeParam as DNSRecordType;
+        const res = (await resolver.resolve(domain, recordType)) as unknown;
+        let records: string[];
         switch (recordType) {
-            case DNSRecordType.A: {
-                const res = await resolver.resolve4(domain);
-                records = res.map(String);
+            case DNSRecordType.MX:
+                records = (res as { priority: number; exchange: string }[]).map(
+                    (mx) => `${mx.priority} ${mx.exchange}`,
+                );
                 break;
-            }
-            case DNSRecordType.AAAA: {
-                const res = await resolver.resolve6(domain);
-                records = res.map(String);
+            case DNSRecordType.TXT:
+                records = (res as string[][]).map((group) => group.join(''));
                 break;
-            }
-            case DNSRecordType.CNAME: {
-                const res = await resolver.resolveCname(domain);
-                records = res.map(String);
-                break;
-            }
-            case DNSRecordType.NS: {
-                const res = await resolver.resolveNs(domain);
-                records = res.map(String);
-                break;
-            }
-            case DNSRecordType.MX: {
-                const res = await resolver.resolveMx(domain);
-                records = res.map((mx) => `${mx.priority} ${mx.exchange}`);
-                break;
-            }
-            case DNSRecordType.TXT: {
-                const res = await resolver.resolveTxt(domain); // string[][]
-                records = res.map((group) => group.join(''));
-                break;
-            }
-            default: {
-                const res = (await resolver.resolve(domain, recordType)) as unknown as string[];
-                records = Array.isArray(res) ? res.map(String) : [];
-            }
+            default:
+                records = Array.isArray(res) ? (res as string[]).map(String) : [];
         }
         return NextResponse.json({ records: { [recordType]: records } });
     } catch {


### PR DESCRIPTION
## Summary
- simplify DNS query handler by using generic `resolver.resolve`
- handle MX and TXT records specially, map others uniformly

## Testing
- `npm test` (fails: jest not found)
- `npm run lint` (fails: next not found)


------
https://chatgpt.com/codex/tasks/task_e_68b2c347173c832ba65848f8382dce1f