### PR TITLE
Add TLD existence check to storage service

### DIFF
--- a/src/services/storage.test.ts
+++ b/src/services/storage.test.ts
@@ -1,0 +1,26 @@
+import { StorageService } from './storage';
+import { TLD } from '@/models/tld';
+
+jest.mock('@supabase/supabase-js', () => ({
+    createClient: jest.fn(() => ({})),
+}));
+
+describe('StorageService', () => {
+    let service: StorageService;
+
+    beforeEach(() => {
+        process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost';
+        process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
+        service = new StorageService();
+    });
+
+    it('returns true when TLD exists', async () => {
+        jest.spyOn(service, 'getTLDByName').mockResolvedValue({ name: 'com' } as TLD);
+        await expect(service.tldExists('com')).resolves.toBe(true);
+    });
+
+    it('returns false when TLD does not exist', async () => {
+        jest.spyOn(service, 'getTLDByName').mockResolvedValue(null);
+        await expect(service.tldExists('nonexistent')).resolves.toBe(false);
+    });
+});

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -39,6 +39,11 @@ class StorageService {
         return data as TLD;
     }
 
+    async tldExists(name: string): Promise<boolean> {
+        const tld = await this.getTLDByName(name);
+        return tld !== null;
+    }
+
     async listTLDs(): Promise<TLD[]> {
         const { data, error } = await this.client
             .from('tld')


### PR DESCRIPTION
## Summary
- add method to check for existing TLD by name
- test new tldExists method

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a13e9f6c832b81fbf37207e122ee