### PR TITLE
feat: set created_at when creating TLD

### DIFF
--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -15,6 +15,7 @@ class StorageService {
             {
                 name: tldInfo.name,
                 description: tldInfo.description,
+                created_at: new Date().toISOString(),
             },
             {
                 onConflict: 'name',


### PR DESCRIPTION
## Summary
- include `created_at` timestamp when upserting TLDs via storage service

## Testing
- `npm test` *(fails: jest: not found)*
- `npm ci 2>&1 | tail -n 20` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68b711b8f484832b8487bfba7a65783c