### PR TITLE
feat(domains): make subdomain inclusion optional

### DIFF
--- a/src/services/domains.test.ts
+++ b/src/services/domains.test.ts
@@ -33,6 +33,11 @@ describe('getDomainsHacks', () => {
         const result = await getDomainsHacks('gates gates');
         expect(result).toEqual([...new Set(result)]);
     });
+
+    it('should allow excluding subdomains when specified', async () => {
+        const result = await getDomainsHacks('bill gates', false);
+        expect(result).toEqual(['gat.es', 'billgat.es']);
+    });
 });
 
 describe('getMatchingDomains', () => {

--- a/src/services/domains.ts
+++ b/src/services/domains.ts
@@ -11,7 +11,10 @@ import { storageService } from './storage';
  * @param input - The input string.
  * @returns A (possibly empty) list of vanity domains for the given input string.
  */
-export async function getDomainsHacks(input: string): Promise<string[]> {
+export async function getDomainsHacks(
+    input: string,
+    includeSubdomains = true,
+): Promise<string[]> {
     input = input.trim().toLowerCase();
 
     // Split the input into words
@@ -40,7 +43,7 @@ export async function getDomainsHacks(input: string): Promise<string[]> {
         const matchingDomains = await getMatchingDomains(candidateName);
         for (const domain of matchingDomains) {
             const level = domain.split('.').length - 1;
-            if (level <= 2) {
+            if (includeSubdomains ? level <= 2 : level <= 1) {
                 domains.push(domain);
             }
         }


### PR DESCRIPTION
## Summary
- add optional parameter to getDomainsHacks to toggle subdomain inclusion
- add unit test covering exclusion of subdomains

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b75c756c58832ba0687adc559b2733