### PR TITLE
feat: add subdomains option to search api

### DIFF
--- a/src/app/api/domains/search/route.ts
+++ b/src/app/api/domains/search/route.ts
@@ -3,6 +3,7 @@ import { getDomainsHacks } from '@/services/domains';
 
 export async function GET(request: Request): Promise<NextResponse> {
     const url = new URL(request.url);
-    const domains = await getDomainsHacks(url.searchParams.get('term') || '');
+    const includeSubdomains = url.searchParams.get('include_subdomains') !== 'false';
+    const domains = await getDomainsHacks(url.searchParams.get('term') || '', includeSubdomains);
     return NextResponse.json({ domains });
 }

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -19,7 +19,8 @@ export function SearchResults() {
         startTransition(async () => {
             try {
                 const term = searchParams.get('term');
-                const names = await apiService.searchDomains(term ?? '');
+                const includeSubdomains = searchParams.get('include_subdomains') !== 'false';
+                const names = await apiService.searchDomains(term ?? '', includeSubdomains);
                 const initialDomains = names.map((name: string) => new Domain(name));
                 initialDomains.sort(
                     (a: Domain, b: Domain) => a.getLevel() - b.getLevel() || a.getName().localeCompare(b.getName()),

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -32,8 +32,10 @@ class ApiService {
         return response.data as TLD;
     }
 
-    async searchDomains(term: string): Promise<string[]> {
-        const response = await this.client.get('/api/domains/search', { params: { term } });
+    async searchDomains(term: string, includeSubdomains = true): Promise<string[]> {
+        const response = await this.client.get('/api/domains/search', {
+            params: { term, include_subdomains: includeSubdomains },
+        });
         return response.data.domains ?? [];
     }
 }


### PR DESCRIPTION
## Summary
- rename domain search query param to `include_subdomains`
- update `ApiService.searchDomains` and `SearchResults` to use the new flag

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-dom)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b765127124832b9729c9054a732f15