### PR TITLE
feat: cache read-only storage methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-loader-spinner": "^6.1.6",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
+    "ts-cacheable": "^1.0.0",
     "validator": "^13.12.0",
     "vaul": "^0.8.0",
     "zustand": "^5.0.2"

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -1,4 +1,5 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { Cacheable } from 'ts-cacheable';
 import { TLD } from '@/models/tld';
 
 class StorageService {
@@ -27,6 +28,7 @@ class StorageService {
         }
     }
 
+    @Cacheable({ ttl: 60 * 60 * 24 })
     async getTLDByName(name: string): Promise<TLD | null> {
         const { data, error } = await this.client.from('tld').select('id, name, description').eq('name', name).single();
         if (error) {
@@ -40,11 +42,13 @@ class StorageService {
         return data as TLD;
     }
 
+    @Cacheable({ ttl: 60 * 60 * 24 })
     async tldExists(name: string): Promise<boolean> {
         const tld = await this.getTLDByName(name);
         return tld !== null;
     }
 
+    @Cacheable({ ttl: 60 * 60 * 24 })
     async listTLDs(): Promise<TLD[]> {
         const { data, error } = await this.client
             .from('tld')


### PR DESCRIPTION
## Summary
- cache Supabase read-only storage methods with ts-cacheable for one day
- add ts-cacheable dependency

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install --package-lock-only` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e14a27fc832b9fb8dc4af36060f3