### PR TITLE
Reduce rate limiter delay to 500ms

### DIFF
--- a/src/components/SearchResult.tsx
+++ b/src/components/SearchResult.tsx
@@ -10,8 +10,8 @@ import DomainDetailDrawer from '@/components/DomainDetailDrawer';
 import DomainStatusBadge from '@/components/DomainStatusBadge';
 import { apiService } from '@/services/api';
 
-// Create a shared rate limiter instance (1 call per second)
-const statusRateLimiter = new RateLimiter(1);
+// Create a shared rate limiter instance (2 calls per second / 500ms delay)
+const statusRateLimiter = new RateLimiter(2);
 
 export function SearchResult({ domain }: { domain: Domain }) {
     const [status, setStatus] = useState<DomainStatusEnum>(DomainStatusEnum.unknown);


### PR DESCRIPTION
## Summary
- halve the delay between domain status checks to 500ms by instantiating the rate limiter with 2 calls per second

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ts-cacheable)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f357c2d4832b9f8ae5601ec86549