### PR TITLE
refactor: align TLD enum with IANA categories

### DIFF
--- a/src/models/tld.ts
+++ b/src/models/tld.ts
@@ -1,16 +1,14 @@
 export enum TLDType {
     // .arpa for technical network infrastructure.
     INFRASTRUCTURE = 'INFRASTRUCTURE',
-    // Generic domains not tied to a country (e.g., .com, .app).
+    // Generic top-level domains not tied to a specific community or country (e.g., .com, .app).
     GENERIC = 'GENERIC',
+    // Generic domains with registration restrictions (e.g., .biz, .name).
+    GENERIC_RESTRICTED = 'GENERIC_RESTRICTED',
     // Community-specific domains run by sponsors (e.g., .edu, .gov).
     SPONSORED = 'SPONSORED',
     // Two-letter country codes (e.g., .uk).
     COUNTRY_CODE = 'COUNTRY_CODE',
-    // Country codes in local scripts (e.g., .中国).
-    IDN_COUNTRY_CODE = 'IDN_COUNTRY_CODE',
-    // Generic domains in non-Latin scripts (e.g., .みんな).
-    IDN_GENERIC = 'IDN_GENERIC',
     // Reserved or special-use domains for testing (e.g., .test).
     TEST = 'TEST',
 }


### PR DESCRIPTION
## Summary
- align TLD categories with IANA groups

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bd7019a010832bab9c6c05a85eedec