### PR TITLE
feat: request plain text TLD descriptions

### DIFF
--- a/src/app/api/cron/sync/enrich_tlds/route.ts
+++ b/src/app/api/cron/sync/enrich_tlds/route.ts
@@ -18,11 +18,11 @@ export async function GET(): Promise<NextResponse> {
                 messages: [
                     {
                         role: 'system',
-                        content: `You are an expert on internet domain name system and top-level domains (TLDs).`,
+                        content: `You are an expert on internet domain name system and top-level domains (TLDs). Responses must be in plain text without markdown formatting.`,
                     },
                     {
                         role: 'user',
-                        content: `Provide a concise description about the TLD "${tld.name}" (max 2 sentences). Explain its purpose, and intended use case.`,
+                        content: `Provide a concise description about the TLD "${tld.name}" (max 2 sentences). Explain its purpose and intended use case using plain text only without markdown.`,
                     },
                 ],
             });


### PR DESCRIPTION
## Summary
- ensure the TLD enrichment prompt requests plain text without markdown

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: ERESOLVE could not resolve)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be8f14e4bc832b9f700b4c1f5cd915