### PR TITLE
Update domain registrar list

### DIFF
--- a/src/components/DomainDetailDrawer.test.tsx
+++ b/src/components/DomainDetailDrawer.test.tsx
@@ -58,28 +58,28 @@ describe('DomainDetailDrawer', () => {
 
         const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
 
-        const godaddyButton = await screen.findByRole('button', { name: /GoDaddy/i });
-        const namecheapButton = screen.getByRole('button', { name: /Namecheap/i });
-        const porkbunButton = screen.getByRole('button', { name: /Porkbun/i });
-
-        fireEvent.click(godaddyButton);
-        expect(openSpy).toHaveBeenNthCalledWith(
-            1,
-            `https://www.godaddy.com/domainsearch/find?domainToCheck=${domain.getName()}`,
-            '_blank',
-        );
-
-        fireEvent.click(namecheapButton);
-        expect(openSpy).toHaveBeenNthCalledWith(
-            2,
-            `https://www.namecheap.com/domains/registration/results/?domain=${domain.getName()}`,
-            '_blank',
-        );
+        const porkbunButton = await screen.findByRole('button', { name: /Porkbun/i });
+        const dynadotButton = screen.getByRole('button', { name: /Dynadot/i });
+        const namecomButton = screen.getByRole('button', { name: /Name.com/i });
 
         fireEvent.click(porkbunButton);
         expect(openSpy).toHaveBeenNthCalledWith(
-            3,
+            1,
             `https://porkbun.com/checkout/search?q=${domain.getName()}`,
+            '_blank',
+        );
+
+        fireEvent.click(dynadotButton);
+        expect(openSpy).toHaveBeenNthCalledWith(
+            2,
+            `https://www.dynadot.com/domain/search.html?domain=${domain.getName()}`,
+            '_blank',
+        );
+
+        fireEvent.click(namecomButton);
+        expect(openSpy).toHaveBeenNthCalledWith(
+            3,
+            `https://www.name.com/domain/search/${domain.getName()}`,
             '_blank',
         );
 
@@ -105,9 +105,9 @@ describe('DomainDetailDrawer', () => {
 
         render(<DomainDetailDrawer domain={domain} status={domain.getStatus()} open={true} onClose={() => {}} />);
 
-        expect(screen.queryByRole('button', { name: /GoDaddy/i })).toBeNull();
-        expect(screen.queryByRole('button', { name: /Namecheap/i })).toBeNull();
         expect(screen.queryByRole('button', { name: /Porkbun/i })).toBeNull();
+        expect(screen.queryByRole('button', { name: /Dynadot/i })).toBeNull();
+        expect(screen.queryByRole('button', { name: /Name.com/i })).toBeNull();
 
         const websiteLink = await screen.findByRole('link', { name: /Visit website/i });
         expect(websiteLink).toHaveAttribute('href', 'https://example.com');

--- a/src/components/DomainRegistrarButtons.tsx
+++ b/src/components/DomainRegistrarButtons.tsx
@@ -8,16 +8,16 @@ interface DomainRegistrarButtonsProps {
 
 const REGISTRARS = [
     {
-        name: 'GoDaddy',
-        url: (domain: string) => `https://www.godaddy.com/domainsearch/find?domainToCheck=${domain}`,
-    },
-    {
-        name: 'Namecheap',
-        url: (domain: string) => `https://www.namecheap.com/domains/registration/results/?domain=${domain}`,
-    },
-    {
         name: 'Porkbun',
         url: (domain: string) => `https://porkbun.com/checkout/search?q=${domain}`,
+    },
+    {
+        name: 'Dynadot',
+        url: (domain: string) => `https://www.dynadot.com/domain/search.html?domain=${domain}`,
+    },
+    {
+        name: 'Name.com',
+        url: (domain: string) => `https://www.name.com/domain/search/${domain}`,
     },
 ];
 


### PR DESCRIPTION
## Summary
- replace GoDaddy and Namecheap with Dynadot and Name.com in registrar buttons
- update tests for new registrar list

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be91584b0c832bb840725efca4ade9