### PR TITLE
feat: add generic TTL cache utility

### DIFF
--- a/src/utils/ttl-cache.test.ts
+++ b/src/utils/ttl-cache.test.ts
@@ -1,0 +1,24 @@
+import { TTLCache } from './ttl-cache';
+
+describe('TTLCache', () => {
+    beforeEach(() => {
+        jest.useFakeTimers({});
+    });
+
+    afterEach(() => {
+        jest.useRealTimers({});
+    });
+
+    it('retrieves values before TTL expires', () => {
+        const cache = new TTLCache<number>();
+        cache.set('a', 1, 1000);
+        expect(cache.get('a')).toBe(1);
+    });
+
+    it('expires values after TTL', () => {
+        const cache = new TTLCache<number>();
+        cache.set('b', 2, 1000);
+        jest.advanceTimersByTime(1001);
+        expect(cache.get('b')).toBeUndefined();
+    });
+});

--- a/src/utils/ttl-cache.ts
+++ b/src/utils/ttl-cache.ts
@@ -1,0 +1,40 @@
+export interface CacheEntry<T> {
+    value: T;
+    expiresAt: number;
+}
+
+/**
+ * A simple in-memory cache with per-entry TTL support.
+ */
+export class TTLCache<T> {
+    private store = new Map<string, CacheEntry<T>>();
+
+    clear(): void {
+        this.store.clear();
+    }
+
+    delete(key: string): void {
+        this.store.delete(key);
+    }
+
+    get(key: string): T | undefined {
+        const entry = this.store.get(key);
+        if (!entry) {
+            return undefined;
+        }
+        if (Date.now() >= entry.expiresAt) {
+            this.store.delete(key);
+            return undefined;
+        }
+        return entry.value;
+    }
+
+    has(key: string): boolean {
+        return this.get(key) !== undefined;
+    }
+
+    set(key: string, value: T, ttlMs: number): void {
+        const expiresAt = Date.now() + ttlMs;
+        this.store.set(key, { value, expiresAt });
+    }
+}


### PR DESCRIPTION
## Summary
- add generic in-memory TTL cache class
- test cache storing and expiration logic
- remove automatic cleaner until needed
- sort TTL cache methods alphabetically
- call Jest timer helpers with explicit empty config objects
- wrap cache miss check in braces for consistent style

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-dom)*
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c130f3a230832b9042c9a81ceedd0e