### PR TITLE
feat: add section headings in domain drawer

### DIFF
--- a/src/components/DomainDetailDrawer.test.tsx
+++ b/src/components/DomainDetailDrawer.test.tsx
@@ -92,6 +92,10 @@ describe('DomainDetailDrawer', () => {
         const whoisParagraph = await screen.findByText(/This domain was created on/i);
         expect(whoisParagraph).toBeInTheDocument();
 
+        expect(await screen.findByRole('heading', { name: /Status/i })).toBeInTheDocument();
+        expect(await screen.findByRole('heading', { name: /Whois info/i })).toBeInTheDocument();
+        expect(await screen.findByRole('heading', { name: /TLD/i })).toBeInTheDocument();
+
         openSpy.mockRestore();
     });
 

--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -105,6 +105,7 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
 
                     <>
                         <Separator />
+                        <h3 className="text-sm font-semibold">Status</h3>
                         <p className="text-xs">
                             <span className="font-bold">{status}:</span> {DOMAIN_STATUS_DESCRIPTIONS[status]}
                             {hasARecord && (
@@ -125,14 +126,16 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                     {whoisInfo && (
                         <>
                             <Separator />
-                            <WhoisInfoSection whoisInfo={whoisInfo} />
+                        <h3 className="text-sm font-semibold">Whois info</h3>
+                        <WhoisInfoSection whoisInfo={whoisInfo} />
                         </>
                     )}
 
                     {tldInfo && (
                         <>
                             <Separator />
-                            <TldSection tld={domain.getTLD()} {...tldInfo} />
+                        <h3 className="text-sm font-semibold">TLD</h3>
+                        <TldSection tld={domain.getTLD()} {...tldInfo} />
                         </>
                     )}
                 </div>


### PR DESCRIPTION
## Summary
- add headings for status, whois info, and TLD sections in the domain detail drawer
- test drawer rendering for new section headings

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c284ced288832baa38032d13a36beb