### PR TITLE
fix tld type extraction to always map to enum

### DIFF
--- a/src/app/api/cron/sync/enrich_tlds_type/route.ts
+++ b/src/app/api/cron/sync/enrich_tlds_type/route.ts
@@ -20,7 +20,9 @@ export async function GET(): Promise<NextResponse> {
                 const typeStr = match?.[1]?.trim().toUpperCase().replace(/-/g, '_');
                 console.log(`Extracted IANA type for ${tld.name}: ${typeStr ?? 'unknown'}`);
                 const type =
-                    (typeStr && TLDType[typeStr as keyof typeof TLDType]) ?? TLDType.GENERIC;
+                    (typeStr
+                        ? TLDType[typeStr as keyof typeof TLDType]
+                        : undefined) ?? TLDType.GENERIC;
                 await storageService.updateTLD(tld.name, { type });
                 console.log(`Updated ${tld.name} with type ${type}`);
             } catch (error) {


### PR DESCRIPTION
## Summary
- ensure TLD enrichment maps extracted string to `TLDType` enum without leaking string types

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68c53f41ddd0832b88534f6ac4e99df5