### PR TITLE
chore: widen loading indicator

### DIFF
--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -63,7 +63,7 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                         </VisuallyHidden>
                     </DrawerHeader>
                     <div className="flex flex-1 flex-col items-center justify-center gap-4 text-sm text-muted-foreground">
-                        <Loading height={48} width={48} />
+                        <Loading height={48} />
                         <span>Hang tight, fetching domain details...</span>
                     </div>
                 </DrawerContent>

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -12,6 +12,7 @@ interface LoadingProps {
     className?: string;
 }
 
-export default function Loading({ height = 120, width = 120, className }: LoadingProps) {
-    return <Player autoplay loop src="/loading.json" style={{ height, width }} className={className} />;
+export default function Loading({ height = 120, width, className }: LoadingProps) {
+    const computedWidth = width ?? (height / 160) * 280;
+    return <Player autoplay loop src="/loading.json" style={{ height, width: computedWidth }} className={className} />;
 }

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -33,7 +33,7 @@ export function SearchResults() {
     if (isPending) {
         return (
             <div className="flex min-h-screen flex-col items-center gap-5 py-24 align-middle">
-                <Loading height={80} width={80} />
+                <Loading height={80} />
                 <p className="text-md text-muted-foreground">Hang tight — your info is on the way…</p>
             </div>
         );


### PR DESCRIPTION
## Summary
- widen loading indicator and derive width from height
- stretch loading state indicators to match animation aspect ratio

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: 403 Forbidden while installing dependencies)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c551ebe478832bbd391fbef66063e8