### PR TITLE
chore: enlarge loading indicator

### DIFF
--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -12,7 +12,7 @@ interface LoadingProps {
     className?: string;
 }
 
-export default function Loading({ height = 120, width, className }: LoadingProps) {
+export default function Loading({ height = 160, width, className }: LoadingProps) {
     const computedWidth = width ?? (height / 160) * 280;
     return <Player autoplay loop src="/loading.json" style={{ height, width: computedWidth }} className={className} />;
 }


### PR DESCRIPTION
## Summary
- increase default loading animation size to 160px height for clearer feedback

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c55401cb74832b9d03650076e746ea