### PR TITLE
Render WHOIS info when partially available

### DIFF
--- a/src/components/WhoisInfoSection.test.tsx
+++ b/src/components/WhoisInfoSection.test.tsx
@@ -25,15 +25,31 @@ describe('WhoisInfoSection', () => {
         const expirationSpan = screen.getByText('January 1st, 2030');
         expect(expirationSpan).toHaveClass('font-bold');
     });
-
-    it('returns null when required info is missing', () => {
+    
+    it('renders partial whois information when some details are missing', () => {
         const partial: WhoisInfo = {
             creationDate: '2025-10-03',
             expirationDate: null,
             registrar: 'Example Registrar',
-            registrarUrl: 'https://example-registrar.com',
+            registrarUrl: null,
         };
+
         render(<WhoisInfoSection whoisInfo={partial} />);
+
+        const paragraph = screen.getByText(/This domain was created on/i);
+        expect(paragraph).toHaveTextContent(
+            'This domain was created on October 3rd, 2025. It is registered with Example Registrar.'
+        );
+    });
+
+    it('returns null when all whois information is missing', () => {
+        const empty: WhoisInfo = {
+            creationDate: null,
+            expirationDate: null,
+            registrar: null,
+            registrarUrl: null,
+        };
+        render(<WhoisInfoSection whoisInfo={empty} />);
 
         expect(screen.queryByText(/This domain was created on/i)).toBeNull();
     });

--- a/src/components/WhoisInfoSection.tsx
+++ b/src/components/WhoisInfoSection.tsx
@@ -8,25 +8,44 @@ interface WhoisInfoSectionProps {
 export function WhoisInfoSection({ whoisInfo }: WhoisInfoSectionProps) {
     const { creationDate, registrarUrl, registrar, expirationDate } = whoisInfo;
 
-    if (!creationDate || !registrarUrl || !expirationDate) {
+    if (!creationDate && !registrarUrl && !registrar && !expirationDate) {
         return null;
     }
 
-    const formattedCreationDate = format(parseISO(creationDate), 'MMMM do, yyyy');
-    const formattedExpirationDate = format(parseISO(expirationDate), 'MMMM do, yyyy');
+    const formattedCreationDate = creationDate ? format(parseISO(creationDate), 'MMMM do, yyyy') : null;
+    const formattedExpirationDate = expirationDate ? format(parseISO(expirationDate), 'MMMM do, yyyy') : null;
 
     return (
         <p className="text-xs">
-            This domain was created on <span className="font-bold">{formattedCreationDate}</span>. It is registered with{' '}
-            <a
-                href={registrarUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-bold text-blue-600 underline"
-            >
-                {registrar ?? registrarUrl}
-            </a>
-            . It is set to expire on <span className="font-bold">{formattedExpirationDate}</span>.
+            {creationDate && (
+                <>
+                    This domain was created on <span className="font-bold">{formattedCreationDate}</span>.
+                    {(registrarUrl || registrar || expirationDate) && ' '}
+                </>
+            )}
+            {(registrarUrl || registrar) && (
+                <>
+                    It is registered with{' '}
+                    {registrarUrl ? (
+                        <a
+                            href={registrarUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="font-bold text-blue-600 underline"
+                        >
+                            {registrar ?? registrarUrl}
+                        </a>
+                    ) : (
+                        <span className="font-bold">{registrar}</span>
+                    )}
+                    {expirationDate && ' '}
+                </>
+            )}
+            {expirationDate && (
+                <>
+                    It is set to expire on <span className="font-bold">{formattedExpirationDate}</span>.
+                </>
+            )}
         </p>
     );
 }


### PR DESCRIPTION
## Summary
- Allow `WhoisInfoSection` to show whichever WHOIS fields are available instead of requiring all
- Extend tests to cover partial and empty WHOIS data cases

## Testing
- `npm test` *(fails: jest: not found)*
- `npm ci` *(fails: 403 Forbidden when installing packages)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c556e1eba4832b9f86b6f4da985c4f