### PR TITLE
feat: add randomized loading messages

### DIFF
--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -3,8 +3,7 @@ import Loading from '@/components/Loading';
 export default function AppLoading() {
     return (
         <div className="flex min-h-screen flex-col items-center gap-5 py-24 align-middle">
-            <Loading />
-            <p className="text-md text-muted-foreground">Hang tight — your info is on the way…</p>
+            <Loading message="Hang tight — your info is on the way…" />
         </div>
     );
 }

--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -62,9 +62,8 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                             <DrawerTitle>Loading domain details</DrawerTitle>
                         </VisuallyHidden>
                     </DrawerHeader>
-                    <div className="flex flex-1 flex-col items-center justify-center gap-4 text-sm text-muted-foreground">
-                        <Loading height={80} />
-                        <span>Hang tight, fetching domain details...</span>
+                    <div className="flex flex-1 items-center justify-center">
+                        <Loading height={80} message="Hang tight, fetching domain details..." />
                     </div>
                 </DrawerContent>
             </Drawer>

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,18 +1,71 @@
 'use client';
 
 import dynamic from 'next/dynamic';
+import { useMemo } from 'react';
+
+import { cn } from '@/lib/utils';
 
 const Player = dynamic(() => import('@lottiefiles/react-lottie-player').then((mod) => mod.Player), {
     ssr: false,
 });
 
+const LOADING_MESSAGES = [
+    'Querying the DNS oracles... please hold.',
+    'Traversing the ICANN multiverse...',
+    'Assembling your domain packets...',
+    'Negotiating with name servers... might take a sec.',
+    'Beaming your request to root servers...',
+    'Hashing some geek magic... almost there!',
+    'Unlocking registrar vaults...',
+    'Caching the uncacheable...',
+    'Summoning domains from the ether...',
+    'Taming penguins in the server racks...',
+    'Aligning domains with the space-time continuum...',
+    'Crunching WHOIS records into human-readable form...',
+    'Pinging alternate realities for availability...',
+    'Rotating encryption keys until one fits...',
+    'Threading connections through registrar fabric...',
+    'Rebooting the hamster powering this server...',
+    'Untangling DNS spaghetti...',
+    'Consulting RFC scrolls for wisdom...',
+    'Waiting for ICANN clearance to land...',
+    'Compiling domain registry spells...',
+    // Extra nerdy easter eggs:
+    'Returning 418: still a teapot... please wait.',
+    'Performing reverse DNS gymnastics...',
+    'Stuck in a CNAME loop... rerouting.',
+    'Retrying after exponential backoff...',
+    'Looking up your domain in Schrödinger’s zone file...',
+    'Query timed out... just kidding.',
+    'Shaking hands over TCP... politely.',
+    'Chasing down dangling PTR records...',
+    'Attempting zone transfer... kidding, that’s illegal.',
+    'Resolving NXDOMAINs into dreams...',
+];
+
 interface LoadingProps {
     height?: number;
     width?: number;
     className?: string;
+    message?: string;
 }
 
-export default function Loading({ height = 160, width, className }: LoadingProps) {
+export default function Loading({ height = 160, width, className, message }: LoadingProps) {
     const computedWidth = width ?? (height / 160) * 280;
-    return <Player autoplay loop src="/loading.json" style={{ height, width: computedWidth }} className={className} />;
+    const displayMessage = useMemo(
+        () => message ?? LOADING_MESSAGES[Math.floor(Math.random() * LOADING_MESSAGES.length)],
+        [message],
+    );
+
+    return (
+        <div
+            className={cn(
+                'flex flex-col items-center justify-center gap-4 text-sm text-muted-foreground',
+                className,
+            )}
+        >
+            <Player autoplay loop src="/loading.json" style={{ height, width: computedWidth }} />
+            <span>{displayMessage}</span>
+        </div>
+    );
 }

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -33,8 +33,7 @@ export function SearchResults() {
     if (isPending) {
         return (
             <div className="flex min-h-screen flex-col items-center gap-5 py-24 align-middle">
-                <Loading height={80} />
-                <p className="text-md text-muted-foreground">Hang tight — your info is on the way…</p>
+                <Loading height={80} message="Hang tight — your info is on the way…" />
             </div>
         );
     }


### PR DESCRIPTION
## Summary
- show a randomized loading message inside the Loading component
- support custom loading messages via a prop
- use the new Loading message in domain drawer, search results and app loading

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c55ad8dbac832b8b2cbd57ef9168df