### PR TITLE
Display domain header while drawer loads details

### DIFF
--- a/src/components/DomainDetailDrawer.test.tsx
+++ b/src/components/DomainDetailDrawer.test.tsx
@@ -40,10 +40,23 @@ describe('DomainDetailDrawer', () => {
             registrar: 'Example Registrar',
             registrarUrl: 'https://example-registrar.com',
         });
+        mockedApiService.getTldInfo.mockResolvedValue({ description: 'Test' });
     });
 
     afterEach(() => {
         mockedApiService.getDomainWhois.mockReset();
+        mockedApiService.getTldInfo.mockReset();
+    });
+
+    it('shows header with domain name and status while loading', () => {
+        const domain = new Domain('example.com');
+        domain.setStatus(DomainStatus.inactive);
+        mockedApiService.getTldInfo.mockImplementation(() => new Promise(() => {}));
+
+        render(<DomainDetailDrawer domain={domain} status={domain.getStatus()} open={true} onClose={() => {}} />);
+
+        expect(screen.getByText(domain.getName())).toBeInTheDocument();
+        expect(screen.getByText(/Available/i)).toBeInTheDocument();
     });
 
     it('shows registrar buttons but hides status and whois info when domain is available', async () => {

--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -12,7 +12,6 @@ import DomainStatusBadge from '@/components/DomainStatusBadge';
 import DomainRegistrarButtons from '@/components/DomainRegistrarButtons';
 import { apiService } from '@/services/api';
 import { TLD } from '@/models/tld';
-import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 
 interface DomainDetailDrawerProps {
     domain: Domain;
@@ -53,23 +52,6 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
         fetchData();
     }, [open, domain]);
 
-    if (loading) {
-        return (
-            <Drawer open={open} onOpenChange={(openState: boolean) => !openState && onClose()} direction="bottom">
-                <DrawerContent className="min-h-[400px]">
-                    <DrawerHeader>
-                        <VisuallyHidden>
-                            <DrawerTitle>Loading domain details</DrawerTitle>
-                        </VisuallyHidden>
-                    </DrawerHeader>
-                    <div className="flex flex-1 items-center justify-center">
-                        <Loading height={80} />
-                    </div>
-                </DrawerContent>
-            </Drawer>
-        );
-    }
-
     return (
         <Drawer open={open} onOpenChange={(openState: boolean) => !openState && onClose()} direction="bottom">
             <DrawerContent className="min-h-[400px]">
@@ -79,40 +61,46 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
                         <DomainStatusBadge domain={domain} status={status} className="min-w-[8rem]" />
                     </DrawerTitle>
                 </DrawerHeader>
-                <div className="space-y-4 p-6 pt-0">
-                    {domain.isAvailable() && (
-                        <>
-                            <Separator />
-                            <DomainRegistrarButtons domainName={domain.getName()} />
-                        </>
-                    )}
+                {loading ? (
+                    <div className="flex flex-1 items-center justify-center">
+                        <Loading height={80} />
+                    </div>
+                ) : (
+                    <div className="space-y-4 p-6 pt-0">
+                        {domain.isAvailable() && (
+                            <>
+                                <Separator />
+                                <DomainRegistrarButtons domainName={domain.getName()} />
+                            </>
+                        )}
 
-                    {!domain.isAvailable() && (
-                        <>
-                            <Separator />
-                            <h3 className="text-xs font-medium uppercase text-muted-foreground">STATUS</h3>
-                            <p className="text-xs">
-                                <span className="font-bold">{status}:</span> {DOMAIN_STATUS_DESCRIPTIONS[status]}
-                            </p>
-                        </>
-                    )}
+                        {!domain.isAvailable() && (
+                            <>
+                                <Separator />
+                                <h3 className="text-xs font-medium uppercase text-muted-foreground">STATUS</h3>
+                                <p className="text-xs">
+                                    <span className="font-bold">{status}:</span> {DOMAIN_STATUS_DESCRIPTIONS[status]}
+                                </p>
+                            </>
+                        )}
 
-                    {!domain.isAvailable() && whoisInfo && (
-                        <>
-                            <Separator />
-                            <h3 className="text-xs font-medium uppercase text-muted-foreground">WHOIS INFO</h3>
-                            <WhoisInfoSection whoisInfo={whoisInfo} />
-                        </>
-                    )}
+                        {!domain.isAvailable() && whoisInfo && (
+                            <>
+                                <Separator />
+                                <h3 className="text-xs font-medium uppercase text-muted-foreground">WHOIS INFO</h3>
+                                <WhoisInfoSection whoisInfo={whoisInfo} />
+                            </>
+                        )}
 
-                    {tldInfo && (
-                        <>
-                            <Separator />
-                            <h3 className="text-xs font-medium uppercase text-muted-foreground">TLD INFO</h3>
-                            <TldSection tld={domain.getTLD()} {...tldInfo} />
-                        </>
-                    )}
-                </div>
+                        {tldInfo && (
+                            <>
+                                <Separator />
+                                <h3 className="text-xs font-medium uppercase text-muted-foreground">TLD INFO</h3>
+                                <TldSection tld={domain.getTLD()} {...tldInfo} />
+                            </>
+                        )}
+                    </div>
+                )}
             </DrawerContent>
         </Drawer>
     );


### PR DESCRIPTION
## Summary
- keep domain name and status visible in the drawer header during loading
- add test ensuring header shows domain name and status while waiting for data

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-dom)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c569118c74832b88446ed2a94ac54e