### PR TITLE
Add punycode tracking to TLD imports

### DIFF
--- a/src/app/api/cron/import_tlds/route.ts
+++ b/src/app/api/cron/import_tlds/route.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { NextResponse } from 'next/server';
 import { storageService } from '@/services/storage';
-import { toUnicode } from 'punycode';
+import { toASCII, toUnicode } from 'punycode';
 
 const IANA_TLD_URL = 'https://data.iana.org/TLD/tlds-alpha-by-domain.txt';
 export const maxDuration = 300; // This function can run for a maximum of 5 minutes
@@ -23,7 +23,8 @@ export async function GET(): Promise<NextResponse> {
                 continue;
             }
 
-            const tldName = toUnicode(trimmed.toLowerCase());
+            const punycodeName = toASCII(trimmed.toLowerCase());
+            const tldName = toUnicode(punycodeName);
             const existingTld = await storageService.getTLD(tldName);
             if (existingTld) {
                 console.log(`TLD ${tldName} already exists. Skipping...`);
@@ -33,6 +34,7 @@ export async function GET(): Promise<NextResponse> {
             console.log(`Creating TLD ${tldName} ...`);
             await storageService.createTld({
                 name: tldName,
+                punycode_name: punycodeName,
             });
         }
         console.log('TLD import completed');

--- a/src/models/tld.ts
+++ b/src/models/tld.ts
@@ -35,6 +35,7 @@ export interface TLDPricing {
 
 export interface TLD {
     name?: string;
+    punycode_name?: string;
     description?: string;
     type?: TLDType;
     pricing?: Partial<Record<Registrar, TLDPricing>>;

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -17,6 +17,7 @@ class StorageService {
         const { error } = await this.client.from('tld').upsert(
             {
                 name: tldInfo.name,
+                punycode_name: tldInfo.punycode_name,
                 description: tldInfo.description,
                 type: tldInfo.type,
                 created_at: new Date().toISOString(),
@@ -43,7 +44,7 @@ class StorageService {
         }
         const { data, error } = await this.client
             .from('tld')
-            .select('name, description, type, pricing')
+            .select('name, punycode_name, description, type, pricing')
             .eq('name', name)
             .single();
         if (error) {
@@ -68,7 +69,7 @@ class StorageService {
 
         const { data, error } = await this.client
             .from('tld')
-            .select('name, type, description, pricing')
+            .select('name, punycode_name, type, description, pricing')
             .order('name', { ascending: true })
             .limit(5000);
         if (error) {


### PR DESCRIPTION
## Summary
- add an optional `punycode_name` field to the `TLD` model so we can store both Unicode and punycode representations
- include the new field in Supabase read/write operations handled by the storage service
- capture the punycode form during the TLD import cron and persist it when inserting new entries

## Testing
- `npm run lint` *(fails: missing local Next.js binary because dependency installation via npm install encountered errors in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbb6abffa4832ba854359d1e635e7e