### PR TITLE
Use filled domain status icons

### DIFF
--- a/src/components/DomainStatusBadge.tsx
+++ b/src/components/DomainStatusBadge.tsx
@@ -3,8 +3,8 @@
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/utils/utils';
 import { Domain, DomainStatus as DomainStatusEnum } from '@/models/domain';
-import { AlertCircle, Loader2 } from 'lucide-react';
-import { CheckCircledIcon, LockClosedIcon } from '@radix-ui/react-icons';
+import { Loader2 } from 'lucide-react';
+import { CheckIcon, ExclamationTriangleIcon, LockClosedIcon } from '@radix-ui/react-icons';
 
 interface DomainStatusBadgeProps {
     domain: Domain;
@@ -12,7 +12,7 @@ interface DomainStatusBadgeProps {
     className?: string;
 }
 
-const baseClasses = 'inline-flex h-7 min-w-[6rem] items-center justify-center px-3';
+const baseClasses = 'inline-flex h-7 min-w-[8rem] items-center justify-center px-3';
 
 function UnknownBadge({ className }: { className?: string }) {
     return (
@@ -28,7 +28,7 @@ function ErrorBadge({ className }: { className?: string }) {
     return (
         <Badge className={cn(baseClasses, 'bg-yellow-400 hover:bg-yellow-500', className)}>
             <div className="flex items-center gap-2">
-                <AlertCircle className="h-4 w-4 text-white" />
+                <ExclamationTriangleIcon className="h-4 w-4 text-white" />
                 <span>Error</span>
             </div>
         </Badge>
@@ -39,7 +39,7 @@ function AvailableBadge({ className }: { className?: string }) {
     return (
         <Badge className={cn(baseClasses, 'bg-green-400 hover:bg-green-600', className)}>
             <div className="flex items-center gap-2">
-                <CheckCircledIcon className="h-4 w-4 text-white" />
+                <CheckIcon className="h-4 w-4 text-white" />
                 <span className="text-white">Available</span>
             </div>
         </Badge>


### PR DESCRIPTION
## Summary
- switch the domain status badges to filled Radix UI icons for availability and error states
- normalize the badge minimum width so every status uses the same footprint

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd0edc81c832ba2573e9b7eb647e8