### PR TITLE
Add lucide icons to TLD type badge

### DIFF
--- a/src/components/TldSection.tsx
+++ b/src/components/TldSection.tsx
@@ -1,19 +1,39 @@
 'use client';
 
-import { TLD } from '@/models/tld';
+import { TLD, TLDType } from '@/models/tld';
 
 import { Badge } from './ui/badge';
+import type { LucideIcon } from 'lucide-react';
+import { CircleHelp, Flag, FlaskConical, Globe2, Handshake, Server, ShieldCheck } from 'lucide-react';
+
+const TLD_TYPE_ICON_MAP: Record<TLDType, LucideIcon> = {
+    [TLDType.COUNTRY_CODE]: Flag,
+    [TLDType.GENERIC]: Globe2,
+    [TLDType.GENERIC_RESTRICTED]: ShieldCheck,
+    [TLDType.INFRASTRUCTURE]: Server,
+    [TLDType.SPONSORED]: Handshake,
+    [TLDType.TEST]: FlaskConical,
+};
+
+const DEFAULT_TLD_TYPE_ICON = CircleHelp;
 
 export default function TLDSection({ name, punycodeName, description, type }: TLD) {
     const ianaURL = `https://www.iana.org/domains/root/db/${punycodeName}.html`;
     const tldDescription = description ?? 'No additional information is available for this TLD.';
+    const TypeIcon = type ? TLD_TYPE_ICON_MAP[type] ?? DEFAULT_TLD_TYPE_ICON : null;
+    const formattedType = type?.replace(/_/g, ' ');
     return (
         <div className="space-y-2">
             <div className="flex items-center gap-2">
                 <Badge variant="outline" className="uppercase">
                     .{name}
                 </Badge>
-                <Badge variant="outline">{type}</Badge>
+                {type && (
+                    <Badge variant="outline" className="flex items-center gap-1 uppercase">
+                        {TypeIcon && <TypeIcon className="h-3 w-3" aria-hidden="true" />}
+                        <span>{formattedType}</span>
+                    </Badge>
+                )}
                 {name !== punycodeName && <Badge variant="outline">INTERNATIONALIZED DOMAIN NAME (IDN)</Badge>}
             </div>
             <p className="gap-2 text-xs leading-relaxed">


### PR DESCRIPTION
## Summary
- map each TLD type to a dedicated Lucide icon and provide a fallback
- render the icon next to the formatted TLD type label in the TLD detail badge

## Testing
- npm run lint *(fails: Cannot find package 'eslint-plugin-unused-imports' imported from eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68ce1d3a30ec832ba0513ad8e278924b