### PR TITLE
Add API route for all TLDs

### DIFF
--- a/src/app/api/tlds/route.ts
+++ b/src/app/api/tlds/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+
+import { tldRepository } from '@/services/tld-repository';
+
+export async function GET(): Promise<NextResponse> {
+    try {
+        // Check if required environment variables are set
+        if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+            return NextResponse.json(
+                {
+                    error: 'Database configuration missing. Please set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY environment variables.',
+                    tlds: [],
+                },
+                { status: 503 },
+            );
+        }
+
+        const tlds = await tldRepository.listTLDs();
+        return NextResponse.json({ tlds });
+    } catch (error) {
+        console.error('Error fetching TLDs:', error);
+        return NextResponse.json({ error: 'Failed to fetch TLDs' }, { status: 500 });
+    }
+}


### PR DESCRIPTION
Add a new API route (`GET /api/tlds`) to return all TLDs from the database.

---
<a href="https://cursor.com/background-agent?bcId=bc-149453ff-0256-4fcd-b5ac-41b5188f9ed8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-149453ff-0256-4fcd-b5ac-41b5188f9ed8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

