### PR TITLE
Enhance dig api for multiple record types

### DIFF
--- a/src/models/dig.ts
+++ b/src/models/dig.ts
@@ -9,5 +9,4 @@ export enum DNSRecordType {
 
 export interface DigInfo {
     records: Partial<Record<DNSRecordType, string[]>>;
-    errors?: Partial<Record<DNSRecordType, string>>;
 }


### PR DESCRIPTION
Update the dig API to resolve multiple DNS record types concurrently, improving performance and flexibility for DNS lookups.

The original API only supported resolving one record type per request. This change allows a single API call to fetch multiple types (e.g., A, AAAA, MX), resolving them in parallel and providing partial results even if some types fail, enhancing efficiency and resilience.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5aa1c1f-16de-4690-9b4f-a4d1de233133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d5aa1c1f-16de-4690-9b4f-a4d1de233133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

