### PR TITLE
Fix libring unicode file issue

### DIFF
--- a/src/utils/unicode.ts
+++ b/src/utils/unicode.ts
@@ -4,8 +4,8 @@ import { direction } from 'direction';
  * Text direction enumeration
  */
 export enum TextDirection {
-  LTR = 'ltr',
-  RTL = 'rtl'
+    LTR = 'ltr',
+    RTL = 'rtl',
 }
 
 /**
@@ -14,14 +14,14 @@ export enum TextDirection {
  * @returns TextDirection enum value indicating the text direction
  */
 export function getTextDirection(text: string): TextDirection {
-  if (!text || text.length === 0) {
-    return TextDirection.LTR;
-  }
+    if (!text || text.length === 0) {
+        return TextDirection.LTR;
+    }
 
-  const detectedDirection = direction(text);
-  
-  // Default neutral and unknown directions to LTR
-  return detectedDirection === 'rtl' ? TextDirection.RTL : TextDirection.LTR;
+    const detectedDirection = direction(text);
+
+    // Default neutral and unknown directions to LTR
+    return detectedDirection === 'rtl' ? TextDirection.RTL : TextDirection.LTR;
 }
 
 /**
@@ -30,7 +30,7 @@ export function getTextDirection(text: string): TextDirection {
  * @returns true if RTL, false otherwise
  */
 export function isRTL(text: string): boolean {
-  return getTextDirection(text) === TextDirection.RTL;
+    return getTextDirection(text) === TextDirection.RTL;
 }
 
 /**
@@ -39,5 +39,5 @@ export function isRTL(text: string): boolean {
  * @returns true if LTR, false otherwise
  */
 export function isLTR(text: string): boolean {
-  return getTextDirection(text) === TextDirection.LTR;
+    return getTextDirection(text) === TextDirection.LTR;
 }


### PR DESCRIPTION
Apply Prettier formatting to `src/utils/unicode.ts` to resolve identified linting errors and address the reported 'libring issue'.

---
<a href="https://cursor.com/background-agent?bcId=bc-34b04641-4a4b-4ad8-94fe-a80e8a48eb13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-34b04641-4a4b-4ad8-94fe-a80e8a48eb13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

