### PR TITLE
Extract and display Whois last updated date

### DIFF
--- a/src/app/api/domains/[name]/whois/route.ts
+++ b/src/app/api/domains/[name]/whois/route.ts
@@ -7,6 +7,8 @@ const RAPID_API_KEY = process.env.RAPID_API_KEY!;
 interface WhoisResult {
     creation_date?: string | string[];
     expiration_date?: string | string[];
+    updated_date?: string | string[];
+    last_updated?: string | string[];
     registrar?: string;
     registrar_url?: string;
 }
@@ -23,11 +25,13 @@ export async function GET(
         const result = (response.data as { result?: WhoisResult }).result;
         const creationRaw = result?.creation_date;
         const expirationRaw = result?.expiration_date;
+        const updatedRaw = result?.updated_date || result?.last_updated;
         const registrar = result?.registrar ?? null;
         const registrarUrl = result?.registrar_url ?? null;
         const creationDate = Array.isArray(creationRaw) ? creationRaw[0] : (creationRaw ?? null);
         const expirationDate = Array.isArray(expirationRaw) ? expirationRaw[0] : (expirationRaw ?? null);
-        return NextResponse.json({ creationDate, expirationDate, registrar, registrarUrl });
+        const lastUpdatedDate = Array.isArray(updatedRaw) ? updatedRaw[0] : (updatedRaw ?? null);
+        return NextResponse.json({ creationDate, expirationDate, lastUpdatedDate, registrar, registrarUrl });
     } catch (error) {
         console.error('Error fetching whois data:', error);
         return NextResponse.json({ error: 'Failed to fetch whois data' }, { status: 500 });

--- a/src/components/DomainStatusSection.tsx
+++ b/src/components/DomainStatusSection.tsx
@@ -25,6 +25,11 @@ export function DomainStatusSection({ status, whoisInfo, digInfo }: DomainStatus
         [whoisInfo?.expirationDate],
     );
 
+    const formattedLastUpdatedDate = useMemo(
+        () => (whoisInfo?.lastUpdatedDate ? format(parseISO(whoisInfo.lastUpdatedDate), 'MMMM do, yyyy') : null),
+        [whoisInfo?.lastUpdatedDate],
+    );
+
     const domainAge = useMemo(
         () =>
             whoisInfo?.creationDate
@@ -98,6 +103,14 @@ export function DomainStatusSection({ status, whoisInfo, digInfo }: DomainStatus
                 <p>
                     <span className="text-muted-foreground">Expires:</span>{' '}
                     <span className="font-medium">{formattedExpirationDate}</span>
+                </p>
+            )}
+
+            {/* Last Updated Date */}
+            {whoisInfo?.lastUpdatedDate && (
+                <p>
+                    <span className="text-muted-foreground">Last Updated:</span>{' '}
+                    <span className="font-medium">{formattedLastUpdatedDate}</span>
                 </p>
             )}
 

--- a/src/components/WhoisInfoSection.tsx
+++ b/src/components/WhoisInfoSection.tsx
@@ -7,14 +7,15 @@ interface WhoisInfoSectionProps {
 }
 
 export function WhoisInfoSection({ whoisInfo }: WhoisInfoSectionProps) {
-    const { creationDate, registrarUrl, registrar, expirationDate } = whoisInfo;
+    const { creationDate, registrarUrl, registrar, expirationDate, lastUpdatedDate } = whoisInfo;
 
-    if (!creationDate && !registrarUrl && !registrar && !expirationDate) {
+    if (!creationDate && !registrarUrl && !registrar && !expirationDate && !lastUpdatedDate) {
         return null;
     }
 
     const formattedCreationDate = creationDate ? format(parseISO(creationDate), 'MMMM do, yyyy') : null;
     const formattedExpirationDate = expirationDate ? format(parseISO(expirationDate), 'MMMM do, yyyy') : null;
+    const formattedLastUpdatedDate = lastUpdatedDate ? format(parseISO(lastUpdatedDate), 'MMMM do, yyyy') : null;
 
     return (
         <p className="text-xs">
@@ -45,6 +46,12 @@ export function WhoisInfoSection({ whoisInfo }: WhoisInfoSectionProps) {
             {expirationDate && (
                 <>
                     Set to expire on <span className="font-bold">{formattedExpirationDate}</span>.
+                    {lastUpdatedDate && ' '}
+                </>
+            )}
+            {lastUpdatedDate && (
+                <>
+                    Last updated on <span className="font-bold">{formattedLastUpdatedDate}</span>.
                 </>
             )}
         </p>

--- a/src/models/whois.ts
+++ b/src/models/whois.ts
@@ -1,6 +1,7 @@
 export interface WhoisInfo {
     creationDate: string | null;
     expirationDate: string | null;
+    lastUpdatedDate: string | null;
     registrar: string | null;
     registrarUrl: string | null;
 }


### PR DESCRIPTION
Add 'last updated at' date to Whois domain status sections to provide more comprehensive domain information.

---
<a href="https://cursor.com/background-agent?bcId=bc-b480ce39-59e7-4e84-95f0-b065fc9f30ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b480ce39-59e7-4e84-95f0-b065fc9f30ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

