### PR TITLE
Rename misleading service names

### DIFF
--- a/src/app/api/domains/search/route.ts
+++ b/src/app/api/domains/search/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from 'next/server';
 
-import { DomainHackGenerator } from '@/services/domain-hack-generator';
+import { DomainHacksGenerator } from '@/services/domain-hacks';
 import { tldRepository } from '@/services/tld-repository';
 
 export async function GET(request: Request): Promise<NextResponse> {
     const url = new URL(request.url);
     const includeSubdomains = url.searchParams.get('include_subdomains') === 'true';
     const tlds = await tldRepository.listTLDs();
-    const domainHackGenerator = new DomainHackGenerator(tlds);
-    const domains = domainHackGenerator.getDomainsHacks(url.searchParams.get('term') || '', includeSubdomains);
+    const domainHacksGenerator = new DomainHacksGenerator(tlds);
+    const domains = domainHacksGenerator.getDomainsHacks(url.searchParams.get('term') || '', includeSubdomains);
     return NextResponse.json({ domains });
 }

--- a/src/services/__tests__/domains.test.ts
+++ b/src/services/__tests__/domains.test.ts
@@ -1,4 +1,4 @@
-import { DomainHackGenerator } from '@/services/domain-hack-generator';
+import { DomainHacksGenerator } from '@/services/domain-hacks';
 
 const TEST_TLDS = [
     { name: 'com' },
@@ -13,11 +13,11 @@ const TEST_TLDS = [
     { name: 'gle' },
 ];
 
-const domainHackGenerator = new DomainHackGenerator(TEST_TLDS);
+const domainHacksGenerator = new DomainHacksGenerator(TEST_TLDS);
 
 describe('getDomainsHacks', () => {
     it('should return correct domains for uppercase input', () => {
-        const result = domainHackGenerator.getDomainsHacks('bill gates');
+        const result = domainHacksGenerator.getDomainsHacks('bill gates');
         expect(result).toContain('gat.es');
         expect(result).toContain('billgat.es');
         expect(result).toContain('bill.gat.es');
@@ -31,7 +31,7 @@ describe('getDomainsHacks', () => {
     });
 
     it('should handle input with extra whitespace and return correct domains', () => {
-        const result = domainHackGenerator.getDomainsHacks(' bill   gates ');
+        const result = domainHacksGenerator.getDomainsHacks(' bill   gates ');
         expect(result).toContain('gat.es');
         expect(result).toContain('billgat.es');
         expect(result).toContain('bill.gat.es');
@@ -45,14 +45,14 @@ describe('getDomainsHacks', () => {
     });
 
     it('should handle single-word input and return correct domains', async () => {
-        const result = domainHackGenerator.getDomainsHacks('google');
+        const result = domainHacksGenerator.getDomainsHacks('google');
         expect(result).toContain('goo.gle');
         expect(result).toContain('g.oo.gle');
         expect(result).toContain('go.o.gle');
     });
 
     it('should handle input with more than three words and combine middle words', async () => {
-        const result = domainHackGenerator.getDomainsHacks('lucio foo bar tudisco');
+        const result = domainHacksGenerator.getDomainsHacks('lucio foo bar tudisco');
         expect(result).toContain('luc.io');
         expect(result).toContain('tudis.co');
         expect(result).toContain('luciotudis.co');
@@ -60,43 +60,43 @@ describe('getDomainsHacks', () => {
     });
 
     it('should return an empty array for an empty input', async () => {
-        const result = domainHackGenerator.getDomainsHacks('');
+        const result = domainHacksGenerator.getDomainsHacks('');
         expect(result).toEqual([]);
     });
 
     it('should remove duplicate domains from the result', async () => {
-        const result = domainHackGenerator.getDomainsHacks('gates gates');
+        const result = domainHacksGenerator.getDomainsHacks('gates gates');
         expect(result).toEqual([...new Set(result)]);
     });
 
     it('should allow excluding subdomains when specified', async () => {
-        const result = await domainHackGenerator.getDomainsHacks('bill gates', false);
+        const result = await domainHacksGenerator.getDomainsHacks('bill gates', false);
         expect(result).toEqual(['gat.es', 'billgat.es']);
     });
 });
 
 describe('getMatchingDomains', () => {
     it('should return correct domains for uppercase input', async () => {
-        const result = domainHackGenerator.getMatchingDomains('NEWMAN');
+        const result = domainHacksGenerator.getMatchingDomains('NEWMAN');
         expect(result).toContain('new.man');
         expect(result).toContain('n.ew.man');
         expect(result).toContain('ne.w.man');
     });
 
     it('should return correct domains for lowercase input', async () => {
-        const result = domainHackGenerator.getMatchingDomains('newman');
+        const result = domainHacksGenerator.getMatchingDomains('newman');
         expect(result).toContain('new.man');
         expect(result).toContain('n.ew.man');
         expect(result).toContain('ne.w.man');
     });
 
     it('should return an empty array when there are no matching domains', async () => {
-        const result = domainHackGenerator.getMatchingDomains('jon');
+        const result = domainHacksGenerator.getMatchingDomains('jon');
         expect(result).toEqual([]);
     });
 
     it('should return multiple domains for input with multiple matching TLDs', async () => {
-        const result = domainHackGenerator.getMatchingDomains('moving');
+        const result = domainHacksGenerator.getMatchingDomains('moving');
         expect(result).toContain('mov.ing');
         expect(result).toContain('movi.ng');
         expect(result).toContain('m.ov.ing');
@@ -107,7 +107,7 @@ describe('getMatchingDomains', () => {
     });
 
     it('should handle numeric input correctly', async () => {
-        const result = domainHackGenerator.getMatchingDomains('124newman');
+        const result = domainHacksGenerator.getMatchingDomains('124newman');
         expect(result).toContain('124new.man');
         expect(result).toContain('1.24new.man');
         expect(result).toContain('12.4new.man');
@@ -117,46 +117,46 @@ describe('getMatchingDomains', () => {
     });
 
     it('should return an empty array for input with invalid characters', async () => {
-        const result = domainHackGenerator.getMatchingDomains('^*&124newman');
+        const result = domainHacksGenerator.getMatchingDomains('^*&124newman');
         expect(result).toEqual([]);
     });
 });
 
 describe('getSubdomains', () => {
     it('should return an empty array if the domain is empty', () => {
-        const result = domainHackGenerator.getSubdomains('');
+        const result = domainHacksGenerator.getSubdomains('');
         expect(result).toEqual([]);
     });
 
     it('should return all subdomains for a given domain label', () => {
-        const result = domainHackGenerator.getSubdomains('lucio');
+        const result = domainHacksGenerator.getSubdomains('lucio');
         expect(result).toEqual(['l.ucio', 'lu.cio', 'luc.io', 'luci.o', 'lucio']);
     });
 });
 
 describe('getMatchingTLDs', () => {
     it('should return an empty array if no TLD matches', async () => {
-        const result = domainHackGenerator.getMatchingTLDs('example');
+        const result = domainHacksGenerator.getMatchingTLDs('example');
         expect(result).toEqual([]);
     });
 
     it('should return a single matching TLD', async () => {
-        const result = domainHackGenerator.getMatchingTLDs('lucio');
+        const result = domainHacksGenerator.getMatchingTLDs('lucio');
         expect(result).toEqual(['io']);
     });
 
     it('should return multiple matching TLDs, if applicable', async () => {
-        const result = domainHackGenerator.getMatchingTLDs('moving');
+        const result = domainHacksGenerator.getMatchingTLDs('moving');
         expect(result.sort()).toEqual(['ing', 'ng'].sort());
     });
 
     it('should be case-insensitive', async () => {
-        const result = domainHackGenerator.getMatchingTLDs('LuCiO');
+        const result = domainHacksGenerator.getMatchingTLDs('LuCiO');
         expect(result).toEqual(['io']);
     });
 
     it('should handle an empty string as input', async () => {
-        const result = domainHackGenerator.getMatchingTLDs('');
+        const result = domainHacksGenerator.getMatchingTLDs('');
         expect(result).toEqual([]);
     });
 });

--- a/src/services/domain-hacks.ts
+++ b/src/services/domain-hacks.ts
@@ -6,7 +6,7 @@ import { TLD } from '@/models/tld';
 /**
  * A service class that powers the search for domain hacks.
  */
-export class DomainHackGenerator {
+export class DomainHacksGenerator {
     private tlds: TLD[];
 
     /**


### PR DESCRIPTION
Rename `domains.ts` to `domain-hacks.ts` and `DomainsService` to `DomainHacksGenerator` to improve clarity and descriptiveness.

---
<a href="https://cursor.com/background-agent?bcId=bc-9962d289-62c7-4da4-86f8-b555090feed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9962d289-62c7-4da4-86f8-b555090feed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

