### PR TITLE
Rename ApiService to APIClient and update references

### DIFF
--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -14,7 +14,7 @@ import { DigInfo } from '@/models/dig';
 import { Domain, DomainStatus as DomainStatusEnum } from '@/models/domain';
 import { TLD } from '@/models/tld';
 import { WhoisInfo } from '@/models/whois';
-import { apiService } from '@/services/api';
+import { apiClient } from '@/services/api';
 
 interface DomainDetailDrawerProps {
     domain: Domain;
@@ -42,9 +42,9 @@ export function DomainDetailDrawer({ domain, status, open, onClose }: DomainDeta
             setLoading(true);
             try {
                 const isAvailable = domain.isAvailable();
-                const whoisPromise = isAvailable ? Promise.resolve(null) : apiService.getDomainWhois(domain.getName());
-                const tldPromise = apiService.getTldInfo(domain.getName());
-                const digPromise = !isAvailable ? apiService.digDomain(domain.getName()) : Promise.resolve(null);
+                const whoisPromise = isAvailable ? Promise.resolve(null) : apiClient.getDomainWhois(domain.getName());
+                const tldPromise = apiClient.getTldInfo(domain.getName());
+                const digPromise = !isAvailable ? apiClient.digDomain(domain.getName()) : Promise.resolve(null);
                 const [whoisData, tldData, digData] = await Promise.all([whoisPromise, tldPromise, digPromise]);
                 setWhoisInfo(whoisData as WhoisInfo);
                 setTldInfo(tldData as TLD);

--- a/src/components/SearchResult.tsx
+++ b/src/components/SearchResult.tsx
@@ -6,7 +6,7 @@ import DomainDetailDrawer from '@/components/DomainDetailDrawer';
 import DomainStatusBadge from '@/components/DomainStatusBadge';
 import { TableCell, TableRow } from '@/components/ui/table';
 import { Domain, DomainStatus as DomainStatusEnum } from '@/models/domain';
-import { apiService } from '@/services/api';
+import { apiClient } from '@/services/api';
 import { RateLimiter } from '@/utils/rate-limiter';
 
 // Create a shared rate limiter instance (2 calls per second / 500ms delay)
@@ -19,7 +19,7 @@ export function SearchResult({ domain }: { domain: Domain }) {
     useEffect(() => {
         const fetchStatus = async () => {
             try {
-                const result = await statusRateLimiter.add(() => apiService.getDomainStatus(domain.getName()));
+                const result = await statusRateLimiter.add(() => apiClient.getDomainStatus(domain.getName()));
                 domain.setStatus(result);
                 setStatus(result);
             } catch (error) {

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -7,7 +7,7 @@ import { SearchResult } from '@/components/SearchResult';
 import NumberTicker from '@/components/ui/number-ticker';
 import { Table, TableBody, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Domain } from '@/models/domain';
-import { apiService } from '@/services/api';
+import { apiClient } from '@/services/api';
 
 const Player = dynamic(() => import('@lottiefiles/react-lottie-player').then((mod) => mod.Player), { ssr: false });
 
@@ -21,7 +21,7 @@ export function SearchResults() {
             try {
                 const term = searchParams.get('term');
                 const includeSubdomains = searchParams.get('include_subdomains') === 'true';
-                const names = await apiService.searchDomains(term ?? '', includeSubdomains);
+                const names = await apiClient.searchDomains(term ?? '', includeSubdomains);
                 const initialDomains = names.map((name: string) => new Domain(name));
                 setDomains(initialDomains);
             } catch (error) {

--- a/src/components/TLDCounter.tsx
+++ b/src/components/TLDCounter.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useTransition } from 'react';
 
 import NumberTicker from '@/components/ui/number-ticker';
-import { apiService } from '@/services/api';
+import { apiClient } from '@/services/api';
 
 export function TLDCounter() {
     const [count, setCount] = useState(0);
@@ -12,7 +12,7 @@ export function TLDCounter() {
     useEffect(() => {
         startTransition(async () => {
             try {
-                const tlds = await apiService.listTLDs();
+                const tlds = await apiClient.listTLDs();
                 setCount(tlds.length);
             } catch (error) {
                 console.error('Error fetching TLD count:', error);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -5,7 +5,7 @@ import { DomainStatus as DomainStatusEnum } from '@/models/domain';
 import { TLD } from '@/models/tld';
 import { WhoisInfo } from '@/models/whois';
 
-class ApiService {
+class APIClient {
     private client: AxiosInstance;
 
     constructor() {
@@ -46,5 +46,5 @@ class ApiService {
     }
 }
 
-export const apiService = new ApiService();
-export type { ApiService };
+export const apiClient = new APIClient();
+export type { APIClient };


### PR DESCRIPTION
Rename `ApiService` class to `APIClient` and its instances to `apiClient` for improved naming consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-f489dc1c-2247-4bb7-aaf1-d675f8a4e9b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f489dc1c-2247-4bb7-aaf1-d675f8a4e9b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

