### PR TITLE
Fix pino-pretty transport target error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
                 "node-html-parser": "^7.0.1",
                 "openai": "^5.19.1",
                 "pino": "^9.11.0",
-                "pino-pretty": "^13.1.1",
                 "punycode": "^2.3.1",
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0",
@@ -5170,6 +5169,7 @@
             "version": "2.0.20",
             "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
             "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/combined-stream": {
@@ -5415,15 +5415,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/kossnocorp"
-            }
-        },
-        "node_modules/dateformat": {
-            "version": "4.6.3",
-            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
-            "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
-            "license": "MIT",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/debug": {
@@ -5796,15 +5787,6 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
             "license": "MIT"
-        },
-        "node_modules/end-of-stream": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-            "license": "MIT",
-            "dependencies": {
-                "once": "^1.4.0"
-            }
         },
         "node_modules/enhanced-resolve": {
             "version": "5.18.0",
@@ -6726,12 +6708,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/fast-copy": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
-            "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
-            "license": "MIT"
-        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6798,12 +6774,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/fast-safe-stringify": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-            "license": "MIT"
         },
         "node_modules/fastq": {
             "version": "1.18.0",
@@ -7427,12 +7397,6 @@
             "bin": {
                 "he": "bin/he"
             }
-        },
-        "node_modules/help-me": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
-            "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
-            "license": "MIT"
         },
         "node_modules/html-encoding-sniffer": {
             "version": "3.0.0",
@@ -9345,15 +9309,6 @@
                 "jiti": "bin/jiti.js"
             }
         },
-        "node_modules/joycon": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
-            "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/js-base64": {
             "version": "3.7.7",
             "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
@@ -10054,6 +10009,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -10454,6 +10410,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
@@ -10745,42 +10702,6 @@
             "license": "MIT",
             "dependencies": {
                 "split2": "^4.0.0"
-            }
-        },
-        "node_modules/pino-pretty": {
-            "version": "13.1.1",
-            "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.1.tgz",
-            "integrity": "sha512-TNNEOg0eA0u+/WuqH0MH0Xui7uqVk9D74ESOpjtebSQYbNWJk/dIxCXIxFsNfeN53JmtWqYHP2OrIZjT/CBEnA==",
-            "license": "MIT",
-            "dependencies": {
-                "colorette": "^2.0.7",
-                "dateformat": "^4.6.3",
-                "fast-copy": "^3.0.2",
-                "fast-safe-stringify": "^2.1.1",
-                "help-me": "^5.0.0",
-                "joycon": "^3.1.1",
-                "minimist": "^1.2.6",
-                "on-exit-leak-free": "^2.1.0",
-                "pino-abstract-transport": "^2.0.0",
-                "pump": "^3.0.0",
-                "secure-json-parse": "^4.0.0",
-                "sonic-boom": "^4.0.1",
-                "strip-json-comments": "^5.0.2"
-            },
-            "bin": {
-                "pino-pretty": "bin.js"
-            }
-        },
-        "node_modules/pino-pretty/node_modules/strip-json-comments": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
-            "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/pino-std-serializers": {
@@ -11242,16 +11163,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/lupomontero"
-            }
-        },
-        "node_modules/pump": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-            "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-            "license": "MIT",
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
             }
         },
         "node_modules/punycode": {
@@ -11807,22 +11718,6 @@
             "engines": {
                 "node": "^14.0.0 || >=16.0.0"
             }
-        },
-        "node_modules/secure-json-parse": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.0.0.tgz",
-            "integrity": "sha512-dxtLJO6sc35jWidmLxo7ij+Eg48PM/kleBsxpC8QJE0qJICe+KawkDQmvCMZUr9u7WKVHgMW6vy3fQ7zMiFZMA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "BSD-3-Clause"
         },
         "node_modules/semver": {
             "version": "7.7.2",
@@ -13540,6 +13435,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
         "node-html-parser": "^7.0.1",
         "openai": "^5.19.1",
         "pino": "^9.11.0",
-        "pino-pretty": "^13.1.1",
         "punycode": "^2.3.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,16 +1,8 @@
 import pino from 'pino';
 
-// Create a logger instance with pino-pretty formatting
+// Create a logger instance with standard JSON output
 const logger = pino({
     level: 'info',
-    transport: {
-        target: 'pino-pretty',
-        options: {
-            colorize: true,
-            translateTime: 'SYS:standard',
-            ignore: 'pid,hostname',
-        },
-    },
 });
 
 export default logger;


### PR DESCRIPTION
Remove pino-pretty dependency and configuration to resolve transport target errors and simplify logging to standard JSON output.

The `pino-pretty` package was causing "unable to determine transport target" errors. Removing it simplifies the logger setup, eliminating the error and providing structured JSON logs, which are more suitable for production environments and log aggregation systems.

---
<a href="https://cursor.com/background-agent?bcId=bc-426b15bc-d489-4a16-b366-5b921cabe9fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-426b15bc-d489-4a16-b366-5b921cabe9fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

