### PR TITLE
Count tlds with limit constant

### DIFF
--- a/src/app/api/tlds/route.ts
+++ b/src/app/api/tlds/route.ts
@@ -3,8 +3,16 @@ import { NextResponse } from 'next/server';
 import { tldRepository } from '@/services/tld-repository';
 import logger from '@/utils/logger';
 
-export async function GET(): Promise<NextResponse> {
+export async function GET(request: Request): Promise<NextResponse> {
     try {
+        const url = new URL(request.url);
+        const action = url.searchParams.get('action');
+
+        if (action === 'count') {
+            const count = await tldRepository.countTLDs();
+            return NextResponse.json({ count });
+        }
+
         const tlds = await tldRepository.listTLDs();
         return NextResponse.json({ tlds });
     } catch (error) {

--- a/src/components/TLDCounter.tsx
+++ b/src/components/TLDCounter.tsx
@@ -12,8 +12,8 @@ function TLDCounter() {
     useEffect(() => {
         startTransition(async () => {
             try {
-                const tlds = await apiClient.getTlds();
-                setCount(tlds.length);
+                const count = await apiClient.getTldCount();
+                setCount(count);
             } catch {
                 // Silently handle error
             }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -52,6 +52,14 @@ class APIClient {
     }
 
     /**
+     * Gets the total count of TLDs.
+     */
+    async getTldCount(): Promise<number> {
+        const response = await this.client.get('/api/tlds?action=count');
+        return response.data.count ?? 0;
+    }
+
+    /**
      * Gets WHOIS data for a registered domain.
      */
     async getWhoisInfo(domain: string): Promise<WhoisInfo> {


### PR DESCRIPTION
Add a server-side TLD counting method and update the `TLDCounter` component to use it, improving efficiency.

The previous implementation of `TLDCounter` fetched all 5000+ TLD records to determine the count, leading to unnecessary data transfer and client-side processing. This change introduces a dedicated API endpoint and repository method to efficiently retrieve only the count from the database, significantly optimizing performance. It also centralizes the TLD limit into a constant.

---
<a href="https://cursor.com/background-agent?bcId=bc-6736a066-f0ea-4610-99ee-2b6389270402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6736a066-f0ea-4610-99ee-2b6389270402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

