### PR TITLE
Fix faq grammar for domain hacks

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -65,7 +65,7 @@ const AboutPage = () => {
                     />
                     <FaqItem
                         question="What are some popular examples of domain hacks?"
-                        answer="Popular examples include bit.ly (bitly) and del.icio.us (delicious), and goo.gl (Google). These domains are memorable because of their distinctive and playful appearance."
+                        answer="Popular examples include bit.ly (bitly), del.icio.us (delicious), and goo.gl (Google). These domains are memorable because of their distinctive and playful appearance."
                         color="#ffd6a5"
                         index={3}
                     />


### PR DESCRIPTION
Fix grammar in 'What are some popular examples of domain hacks?' FAQ by correcting list formatting.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4821dde-b60c-41bf-9026-9bc03307026e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b4821dde-b60c-41bf-9026-9bc03307026e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

