### PR TITLE
Style about page .com link

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -37,7 +37,7 @@ const AboutPage = () => {
                     <Badge className="text-xs font-medium">ABOUT</Badge>
                     <h1 className="mt-4 text-2xl font-semibold lg:text-4xl">Domain Hacks</h1>
                     <p className="mt-4 text-sm font-medium text-muted-foreground lg:mt-6 lg:text-base">
-                        Forget ".com". Get a domain that truly{' '}
+                        Forget <span className="font-medium line-through">.com</span>. Get a domain that truly{' '}
                         <Highlighter action="highlight" color="#fde2e4">
                             stand out
                         </Highlighter>


### PR DESCRIPTION
Modify about page to remove quotes around ".com", add a strike effect, and apply medium bold styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-a345acc8-d668-4f9d-941c-c3819a9e2b13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a345acc8-d668-4f9d-941c-c3819a9e2b13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

