### PR TITLE
Handle empty wiki pages

### DIFF
--- a/src/app/api/cron/tlds/update_description/route.ts
+++ b/src/app/api/cron/tlds/update_description/route.ts
@@ -108,7 +108,7 @@ const TLD_SCHEMA = {
                     'The description should be non-technical and easy to understand.',
                     'The description should include a brief history of the TLD, its intended use and any other interesting facts.',
                     'If it is a brand TLD, note the sponsoring organization.',
-                    'Highlight if registrations are restricted',
+                    'Highlight if registrations are restricted.',
                     'Spell out acronyms and abbreviations at first mention.',
                 ].join(' '),
             },


### PR DESCRIPTION
This pull request enhances the TLD enrichment cron job by improving how descriptions and types are fetched and processed. The changes make the enrichment process more robust by handling missing wiki pages gracefully and refining the way HTML content is extracted and passed to the OpenAI model. The schema for TLD descriptions has also been updated to provide clearer guidance for generating metadata.

### Improvements to TLD enrichment logic

* Added error handling for missing ICANN and IANA wiki pages, allowing the process to skip TLDs when relevant pages are not found instead of failing the whole job.
* Changed the way HTML content from ICANN and IANA wiki pages is extracted—now using the full text content, and passing it to the OpenAI model in a clearer format. [[1]](diffhunk://#diff-7be75c0796fbded0a32cb6fb0fa3b9203dd4a569f568772df9f370309ea27d75R25-R57) [[2]](diffhunk://#diff-7be75c0796fbded0a32cb6fb0fa3b9203dd4a569f568772df9f370309ea27d75L43-R87)

### Updates to OpenAI prompt and schema

* Refined the system and user prompts sent to the OpenAI model to clarify the expected output and improve context, including more detailed instructions for generating structured metadata.
* Updated the `TLD_SCHEMA` description requirements to emphasize non-technical language, brief history, intended use, and interesting facts, and removed strict length constraints.

### General improvements

* Updated function and log messages to reflect that both description and type are now enriched, not just description. [[1]](diffhunk://#diff-7be75c0796fbded0a32cb6fb0fa3b9203dd4a569f568772df9f370309ea27d75L12-R13) [[2]](diffhunk://#diff-7be75c0796fbded0a32cb6fb0fa3b9203dd4a569f568772df9f370309ea27d75L43-R87)