### PR TITLE
Update descriptions

### DIFF
--- a/src/app/api/cron/tlds/update_description/route.ts
+++ b/src/app/api/cron/tlds/update_description/route.ts
@@ -37,8 +37,9 @@ export async function GET(): Promise<NextResponse> {
             } catch (error) {
                 if (isAxiosError(error) && error.response?.status === 404) {
                     logger.warn(`ICANN wiki page not found for TLD ${tld.name}.`);
+                } else {
+                    throw error;
                 }
-                throw error;
             }
 
             try {
@@ -47,8 +48,9 @@ export async function GET(): Promise<NextResponse> {
             } catch (error) {
                 if (isAxiosError(error) && error.response?.status === 404) {
                     logger.warn(`IANA wiki page not found for TLD ${tld.name}.`);
+                } else {
+                    throw error;
                 }
-                throw error;
             }
 
             const response = await openaiClient.chat.completions.create({


### PR DESCRIPTION
This pull request refactors the error handling logic for fetching ICANN and IANA wiki pages in the TLD description update API route. The main improvement is that the function no longer skips processing a TLD when a wiki page is missing; instead, it logs a warning and continues, allowing descriptions to be updated even if one source is unavailable.

**Error handling improvements:**

* Changed the error handling for missing ICANN and IANA wiki pages to log a warning and continue processing, rather than skipping the TLD entirely. This ensures that the description update process is more resilient to missing data sources.
* Updated the error type checking to use the imported `isAxiosError` function instead of `axios.isAxiosError` for consistency and clarity.

**Code style and initialization:**

* Initialized `icannWiki` and `ianaWiki` variables as empty strings to avoid potential undefined values and clarify intent.
* Renamed response variables for clarity (`icannWikiResponse` → `icannResponse`, `ianaWikiResponse` → `ianaResponse`).