### PR TITLE
Handle empty wiki pages

### DIFF
--- a/src/components/DomainDetailDrawer.tsx
+++ b/src/components/DomainDetailDrawer.tsx
@@ -12,19 +12,18 @@ import LoadingMessage from '@/components/LoadingMessage';
 import TLDSection from '@/components/TLDSection';
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
 import { Separator } from '@/components/ui/separator';
-import { Domain, DomainStatus as DomainStatusEnum } from '@/models/domain';
+import { Domain } from '@/models/domain';
 import { TLD } from '@/models/tld';
 import { WhoisInfo } from '@/models/whois';
 import { apiClient } from '@/services/api';
 
 interface DomainDetailDrawerProps {
     domain: Domain;
-    status: DomainStatusEnum;
     open: boolean;
     onClose: () => void;
 }
 
-function DomainDetailDrawer({ domain, status, open, onClose }: DomainDetailDrawerProps) {
+function DomainDetailDrawer({ domain, open, onClose }: DomainDetailDrawerProps) {
     const [hasError, setHasError] = useState(false);
     const [loading, setLoading] = useState(false);
     const [tldInfo, setTldInfo] = useState<TLD | null>(null);
@@ -94,7 +93,7 @@ function DomainDetailDrawer({ domain, status, open, onClose }: DomainDetailDrawe
                 <DrawerHeader>
                     <DrawerTitle className="flex items-center justify-between">
                         <div className="flex max-w-[400px] items-center gap-2 truncate">{domain.getName()}</div>
-                        <DomainStatusBadge domain={domain} status={status} className="min-w-[8rem]" />
+                        <DomainStatusBadge status={domain.getStatus()} className="min-w-[8rem]" />
                     </DrawerTitle>
                 </DrawerHeader>
                 <div className="space-y-4 p-6 pt-0">
@@ -108,7 +107,7 @@ function DomainDetailDrawer({ domain, status, open, onClose }: DomainDetailDrawe
                     {!domain.isAvailable() && (
                         <>
                             <Separator />
-                            <DomainStatusSection status={status} />
+                            <DomainStatusSection status={domain.getStatus()} />
                         </>
                     )}
 

--- a/src/components/DomainStatusBadge.tsx
+++ b/src/components/DomainStatusBadge.tsx
@@ -3,12 +3,11 @@
 import { Loader2 } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
-import { Domain, DomainStatus as DomainStatusEnum } from '@/models/domain';
+import { DOMAIN_AVAILABLE_STATUS_VALUES, DomainStatus } from '@/models/domain';
 import { cn } from '@/utils/utils';
 
 interface DomainStatusBadgeProps {
-    domain: Domain;
-    status: DomainStatusEnum;
+    status: DomainStatus;
     className?: string;
 }
 
@@ -48,16 +47,16 @@ function TakenBadge({ className }: { className?: string }) {
     );
 }
 
-function DomainStatusBadge({ domain, status, className }: DomainStatusBadgeProps) {
-    if (status === DomainStatusEnum.UNKNOWN) {
+function DomainStatusBadge({ status, className }: DomainStatusBadgeProps) {
+    if (status === DomainStatus.UNKNOWN) {
         return <UnknownBadge className={className} />;
     }
 
-    if (status === DomainStatusEnum.ERROR) {
+    if (status === DomainStatus.ERROR) {
         return <ErrorBadge className={className} />;
     }
 
-    if (domain.isAvailable()) {
+    if (DOMAIN_AVAILABLE_STATUS_VALUES.has(status)) {
         return <AvailableBadge className={className} />;
     }
 

--- a/src/components/SearchResult.tsx
+++ b/src/components/SearchResult.tsx
@@ -38,11 +38,11 @@ export function SearchResult({ domain }: { domain: Domain }) {
                 </TableCell>
                 <TableCell className="text-right">
                     <div className="flex items-center justify-end gap-2">
-                        <DomainStatusBadge domain={domain} status={status} />
+                        <DomainStatusBadge status={status} />
                     </div>
                 </TableCell>
             </TableRow>
-            <DomainDetailDrawer domain={domain} status={status} open={open} onClose={() => setOpen(false)} />
+            <DomainDetailDrawer domain={domain} open={open} onClose={() => setOpen(false)} />
         </>
     );
 }

--- a/src/components/__tests__/DomainStatusBadge.test.tsx
+++ b/src/components/__tests__/DomainStatusBadge.test.tsx
@@ -1,21 +1,13 @@
 import { render, screen } from '@testing-library/react';
 
 import DomainStatusBadge from '@/components/DomainStatusBadge';
-import { Domain, DomainStatus } from '@/models/domain';
+import { DomainStatus } from '@/models/domain';
 
 describe('DomainStatusBadge', () => {
-    const createDomainWithStatus = (status: DomainStatus): Domain => {
-        const domain = new Domain('example.com');
-        domain.setStatus(status);
-        return domain;
-    };
-
     describe('Unknown Status', () => {
         it('should render loading spinner for unknown status', () => {
-            const domain = createDomainWithStatus(DomainStatus.UNKNOWN);
-            render(<DomainStatusBadge domain={domain} status={DomainStatus.UNKNOWN} />);
+            render(<DomainStatusBadge status={DomainStatus.UNKNOWN} />);
 
-            // Check for the loading spinner
             const spinner = document.querySelector('.animate-spin');
             expect(spinner).toBeInTheDocument();
         });
@@ -23,8 +15,7 @@ describe('DomainStatusBadge', () => {
 
     describe('Error Status', () => {
         it('should render error badge for error status', () => {
-            const domain = createDomainWithStatus(DomainStatus.ERROR);
-            render(<DomainStatusBadge domain={domain} status={DomainStatus.ERROR} />);
+            render(<DomainStatusBadge status={DomainStatus.ERROR} />);
 
             expect(screen.getByText('Error')).toBeInTheDocument();
         });
@@ -32,8 +23,7 @@ describe('DomainStatusBadge', () => {
 
     describe('Available Status', () => {
         it('should render available badge when domain is available', () => {
-            const domain = createDomainWithStatus(DomainStatus.INACTIVE);
-            render(<DomainStatusBadge domain={domain} status={DomainStatus.INACTIVE} />);
+            render(<DomainStatusBadge status={DomainStatus.INACTIVE} />);
 
             expect(screen.getByText('Available')).toBeInTheDocument();
         });
@@ -41,8 +31,7 @@ describe('DomainStatusBadge', () => {
 
     describe('Taken Status', () => {
         it('should render taken badge when domain is not available', () => {
-            const domain = createDomainWithStatus(DomainStatus.ACTIVE);
-            render(<DomainStatusBadge domain={domain} status={DomainStatus.ACTIVE} />);
+            render(<DomainStatusBadge status={DomainStatus.ACTIVE} />);
 
             expect(screen.getByText('Taken')).toBeInTheDocument();
         });

--- a/src/models/domain.ts
+++ b/src/models/domain.ts
@@ -98,7 +98,7 @@ export enum DomainStatus {
     ERROR = 'ERROR',
 }
 
-const DOMAIN_AVAILABLE_STATUS_VALUES = new Set([
+export const DOMAIN_AVAILABLE_STATUS_VALUES = new Set([
     DomainStatus.INACTIVE,
     DomainStatus.PREMIUM,
     DomainStatus.TRANSFERABLE,


### PR DESCRIPTION
This pull request refactors how domain status is handled and passed between components, simplifying the interface and improving code clarity. The main change is to remove the dependency on the entire `Domain` object for status display components, instead passing only the status value. This affects several components and their tests.

**Component API Simplification:**

* Refactored `DomainStatusBadge` and related components to accept only a `status` prop (of type `DomainStatus`), removing the need to pass the entire `Domain` object. This change streamlines the interface and reduces unnecessary coupling. [[1]](diffhunk://#diff-4c69c41b90e9d49a8f76242fbe6434605879ea5fc974b413dcf9824f57ef5c53L6-R10) [[2]](diffhunk://#diff-826f3a5739de8c69793b6c2e26a76d91f7f4454f3759877c950fbc0e9c81c4e6L15-R26) [[3]](diffhunk://#diff-00f4d4b404c69580c4b85d0f084eaec230818384186c43a23a9d832d58b99d8fL41-R45)

* Updated usages of `DomainStatusBadge` and `DomainDetailDrawer` in various components (`DomainDetailDrawer.tsx`, `SearchResult.tsx`) to pass only the `status` instead of both `domain` and `status`. [[1]](diffhunk://#diff-826f3a5739de8c69793b6c2e26a76d91f7f4454f3759877c950fbc0e9c81c4e6L97-R96) [[2]](diffhunk://#diff-826f3a5739de8c69793b6c2e26a76d91f7f4454f3759877c950fbc0e9c81c4e6L111-R110) [[3]](diffhunk://#diff-00f4d4b404c69580c4b85d0f084eaec230818384186c43a23a9d832d58b99d8fL41-R45)

**Logic and Utility Improvements:**

* Replaced status checks that relied on domain methods (e.g., `domain.isAvailable()`) with direct checks against a new exported constant set, `DOMAIN_AVAILABLE_STATUS_VALUES`, for better clarity and maintainability. [[1]](diffhunk://#diff-4c69c41b90e9d49a8f76242fbe6434605879ea5fc974b413dcf9824f57ef5c53L51-R59) [[2]](diffhunk://#diff-066da8abd0da6a8a8913029a100605a0e777c1753d9fd7b30336f54813d574b6L101-R101)

**Test Updates:**

* Simplified tests for `DomainStatusBadge` by removing the need to construct domain objects and updating them to use only the status prop.