### PR TITLE
Add default api client timeout

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -14,7 +14,9 @@ class APIClient {
      * Creates axios instance for API requests.
      */
     constructor() {
-        this.client = axios.create();
+        this.client = axios.create({
+            timeout: 15000, // 15 seconds default timeout
+        });
     }
 
     /**


### PR DESCRIPTION
Add a default 15-second timeout to the API client to prevent requests from hanging indefinitely.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba10e02e-f69f-4ffe-991a-e7089e908de7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ba10e02e-f69f-4ffe-991a-e7089e908de7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

