### PR TITLE
Sitemaps

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,14 @@
+import { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+    return {
+        rules: [
+            {
+                userAgent: '*',
+                allow: '/',
+                disallow: ['/api/'],
+            },
+        ],
+        sitemap: 'https://getmyna.me/sitemap.xml',
+    };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,26 @@
+import { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+    const baseUrl = 'https://getmyna.me';
+
+    return [
+        {
+            url: baseUrl,
+            lastModified: new Date(),
+            changeFrequency: 'weekly',
+            priority: 1,
+        },
+        {
+            url: `${baseUrl}/about`,
+            lastModified: new Date(),
+            changeFrequency: 'monthly',
+            priority: 0.8,
+        },
+        {
+            url: `${baseUrl}/search`,
+            lastModified: new Date(),
+            changeFrequency: 'daily',
+            priority: 0.9,
+        },
+    ];
+}

--- a/src/components/DomainWhoisSection.tsx
+++ b/src/components/DomainWhoisSection.tsx
@@ -11,7 +11,7 @@ interface DomainWhoisSectionProps {
 export function DomainWhoisSection({ whoisInfo }: DomainWhoisSectionProps) {
     const formattedCreationDate = formatDate(whoisInfo?.creationDate);
     const formattedExpirationDate = formatDate(whoisInfo?.expirationDate);
-    const domainAge = getDomainAge(whoisInfo?.creationDate);
+    const domainAge = getAge(whoisInfo?.creationDate);
 
     function formatDate(dateString: string | undefined): string | null {
         if (!dateString) {
@@ -20,7 +20,7 @@ export function DomainWhoisSection({ whoisInfo }: DomainWhoisSectionProps) {
         return format(parseISO(dateString), 'MMMM do, yyyy');
     }
 
-    function getDomainAge(dateString: string | undefined): string | null {
+    function getAge(dateString: string | undefined): string | null {
         if (!dateString) {
             return null;
         }

--- a/src/services/tld-repository.ts
+++ b/src/services/tld-repository.ts
@@ -1,3 +1,5 @@
+'server-only';
+
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
 import { TLD } from '@/models/tld';


### PR DESCRIPTION
This pull request introduces new metadata handling for SEO and refines some component logic. The main changes include adding dedicated routes for `robots.txt` and `sitemap.xml` using Next.js conventions, and a small refactor in the `DomainWhoisSection` component for improved function naming clarity.

**SEO and Metadata Improvements:**

* Added a new `robots.ts` file in `src/app` to generate a custom `robots.txt` with specific allow/disallow rules and a sitemap reference.
* Added a new `sitemap.ts` file in `src/app` to programmatically generate a sitemap with URLs, last modified dates, change frequency, and priority for main site pages.

**Component Refactoring:**

* Renamed the `getDomainAge` function to `getAge` in `DomainWhoisSection.tsx` for improved clarity and consistency. [[1]](diffhunk://#diff-55ff333893f0ac73e71603d203d78b982a5d39f933dde7d34ae875da8375f9c0L14-R14) [[2]](diffhunk://#diff-55ff333893f0ac73e71603d203d78b982a5d39f933dde7d34ae875da8375f9c0L23-R23)

**Miscellaneous:**

* Added `'server-only';` directive to the top of `src/services/tld-repository.ts` to ensure server-side execution.