### PR TITLE
Expose TLDs endpoint

### DIFF
--- a/src/app/api/tlds/__tests__/route.test.ts
+++ b/src/app/api/tlds/__tests__/route.test.ts
@@ -10,60 +10,58 @@ describe('/api/tlds', () => {
         jest.clearAllMocks();
     });
 
-    describe('GET', () => {
-        it('should return all TLDs when repository succeeds', async () => {
-            const mockTLDs: TLD[] = [
-                {
-                    name: 'com',
-                    punycodeName: 'com',
-                    type: TLDType.GENERIC,
-                    description: 'Commercial',
-                    pricing: {},
-                },
-                {
-                    name: 'org',
-                    punycodeName: 'org',
-                    type: TLDType.GENERIC,
-                    description: 'Organization',
-                    pricing: {},
-                },
-                {
-                    name: 'uk',
-                    punycodeName: 'uk',
-                    type: TLDType.COUNTRY_CODE,
-                    description: 'United Kingdom',
-                    pricing: {},
-                },
-            ];
-            mockTldRepository.listTLDs.mockResolvedValue(mockTLDs);
+    it('should return all TLDs when repository succeeds', async () => {
+        const mockTLDs: TLD[] = [
+            {
+                name: 'com',
+                punycodeName: 'com',
+                type: TLDType.GENERIC,
+                description: 'Commercial',
+                pricing: {},
+            },
+            {
+                name: 'org',
+                punycodeName: 'org',
+                type: TLDType.GENERIC,
+                description: 'Organization',
+                pricing: {},
+            },
+            {
+                name: 'uk',
+                punycodeName: 'uk',
+                type: TLDType.COUNTRY_CODE,
+                description: 'United Kingdom',
+                pricing: {},
+            },
+        ];
+        mockTldRepository.listTLDs.mockResolvedValue(mockTLDs);
 
-            const response = await GET();
-            const responseData = await response.json();
+        const response = await GET();
+        const responseData = await response.json();
 
-            expect(response.status).toBe(200);
-            expect(responseData).toEqual({ tlds: mockTLDs });
-            expect(mockTldRepository.listTLDs).toHaveBeenCalledTimes(1);
-        });
+        expect(response.status).toBe(200);
+        expect(responseData).toEqual({ tlds: mockTLDs });
+        expect(mockTldRepository.listTLDs).toHaveBeenCalledTimes(1);
+    });
 
-        it('should return empty array when no TLDs exist', async () => {
-            mockTldRepository.listTLDs.mockResolvedValue([]);
+    it('should return empty array when no TLDs exist', async () => {
+        mockTldRepository.listTLDs.mockResolvedValue([]);
 
-            const response = await GET();
-            const responseData = await response.json();
+        const response = await GET();
+        const responseData = await response.json();
 
-            expect(response.status).toBe(200);
-            expect(responseData).toEqual({ tlds: [] });
-        });
+        expect(response.status).toBe(200);
+        expect(responseData).toEqual({ tlds: [] });
+    });
 
-        it('should return 500 when request fails', async () => {
-            const mockError = new Error('Database connection failed');
-            mockTldRepository.listTLDs.mockRejectedValue(mockError);
+    it('should return 500 when request fails', async () => {
+        const mockError = new Error('Database connection failed');
+        mockTldRepository.listTLDs.mockRejectedValue(mockError);
 
-            const response = await GET();
-            const responseData = await response.json();
+        const response = await GET();
+        const responseData = await response.json();
 
-            expect(response.status).toBe(500);
-            expect(responseData).toEqual({ error: 'Internal server error' });
-        });
+        expect(response.status).toBe(500);
+        expect(responseData).toEqual({ error: 'Internal server error' });
     });
 });

--- a/src/app/api/tlds/__tests__/route.test.ts
+++ b/src/app/api/tlds/__tests__/route.test.ts
@@ -1,0 +1,69 @@
+import { GET } from '@/app/api/tlds/route';
+import { TLD, TLDType } from '@/models/tld';
+import { tldRepository } from '@/services/tld-repository';
+
+jest.mock('@/services/tld-repository');
+const mockTldRepository = tldRepository as jest.Mocked<typeof tldRepository>;
+
+describe('/api/tlds', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('GET', () => {
+        it('should return all TLDs when repository succeeds', async () => {
+            const mockTLDs: TLD[] = [
+                {
+                    name: 'com',
+                    punycodeName: 'com',
+                    type: TLDType.GENERIC,
+                    description: 'Commercial',
+                    pricing: {},
+                },
+                {
+                    name: 'org',
+                    punycodeName: 'org',
+                    type: TLDType.GENERIC,
+                    description: 'Organization',
+                    pricing: {},
+                },
+                {
+                    name: 'uk',
+                    punycodeName: 'uk',
+                    type: TLDType.COUNTRY_CODE,
+                    description: 'United Kingdom',
+                    pricing: {},
+                },
+            ];
+            mockTldRepository.listTLDs.mockResolvedValue(mockTLDs);
+
+            const response = await GET();
+            const responseData = await response.json();
+
+            expect(response.status).toBe(200);
+            expect(responseData).toEqual({ tlds: mockTLDs });
+            expect(mockTldRepository.listTLDs).toHaveBeenCalledTimes(1);
+        });
+
+        it('should return empty array when no TLDs exist', async () => {
+            mockTldRepository.listTLDs.mockResolvedValue([]);
+
+            const response = await GET();
+            const responseData = await response.json();
+
+            expect(response.status).toBe(200);
+            expect(responseData).toEqual({ tlds: [] });
+        });
+
+        it('should return 500 when request fails', async () => {
+            const mockError = new Error('Database connection failed');
+            mockTldRepository.listTLDs.mockRejectedValue(mockError);
+
+            const response = await GET();
+            const responseData = await response.json();
+
+            expect(response.status).toBe(500);
+            expect(responseData).toEqual({ error: 'Internal server error' });
+        });
+    });
+});

--- a/src/app/api/tlds/route.ts
+++ b/src/app/api/tlds/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+import { tldRepository } from '@/services/tld-repository';
+import logger from '@/utils/logger';
+
+export async function GET(): Promise<NextResponse> {
+    try {
+        const tlds = await tldRepository.listTLDs();
+        return NextResponse.json({ tlds });
+    } catch (error) {
+        logger.error({ error }, 'Error fetching TLDs');
+        return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    }
+}


### PR DESCRIPTION
Expose `/api/tlds` endpoint to return the full list of TLDs.

---
<a href="https://cursor.com/background-agent?bcId=bc-17fb701d-e18f-4801-818a-708acbdcacbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-17fb701d-e18f-4801-818a-708acbdcacbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

