### PR TITLE
Create tlds page with list item component

### DIFF
--- a/src/app/tlds/page.tsx
+++ b/src/app/tlds/page.tsx
@@ -1,0 +1,95 @@
+import { Flag, FlaskConical, Globe2, Handshake, type LucideIcon, Server, ShieldCheck } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Highlighter } from '@/components/ui/highlighter';
+import { Registrar, TLD, TLDType } from '@/models/tld';
+import { tldRepository } from '@/services/tld-repository';
+
+const TLD_TYPE_ICONS: Record<TLDType, LucideIcon> = {
+    [TLDType.COUNTRY_CODE]: Flag,
+    [TLDType.GENERIC]: Globe2,
+    [TLDType.GENERIC_RESTRICTED]: ShieldCheck,
+    [TLDType.INFRASTRUCTURE]: Server,
+    [TLDType.SPONSORED]: Handshake,
+    [TLDType.TEST]: FlaskConical,
+};
+
+const TLD_TYPE_DISPLAY_NAMES: Record<TLDType, string> = {
+    [TLDType.COUNTRY_CODE]: 'Country Code',
+    [TLDType.GENERIC]: 'Generic',
+    [TLDType.GENERIC_RESTRICTED]: 'Generic Restricted',
+    [TLDType.INFRASTRUCTURE]: 'Infrastructure',
+    [TLDType.SPONSORED]: 'Sponsored',
+    [TLDType.TEST]: 'Test',
+};
+
+const REGISTRAR_DISPLAY_NAMES: Record<Registrar, string> = {
+    [Registrar.DYNADOT]: 'Dynadot',
+    [Registrar.GANDI]: 'Gandi',
+    [Registrar.NAMECOM]: 'Name.com',
+    [Registrar.NAMESILO]: 'NameSilo',
+    [Registrar.PORKBUN]: 'Porkbun',
+};
+
+export default async function TldsPage() {
+    const tlds = await tldRepository.listTLDs();
+
+    // Local component defined inside the page
+    function TldListItem({ tld }: { tld: TLD }) {
+        const Icon = tld.type ? TLD_TYPE_ICONS[tld.type] : null;
+        const typeDisplayName = tld.type ? TLD_TYPE_DISPLAY_NAMES[tld.type] : null;
+
+        // Extract registrars from pricing
+        const registrars = tld.pricing
+            ? Object.keys(tld.pricing)
+                  .map((key) => REGISTRAR_DISPLAY_NAMES[key as Registrar])
+                  .filter(Boolean)
+            : [];
+
+        return (
+            <div className="flex flex-col gap-3 rounded-lg border border-border bg-card p-4 transition-all hover:border-primary/50 hover:shadow-sm">
+                <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-lg font-bold text-foreground">.{tld.name}</span>
+                    {tld.type && (
+                        <Badge variant="outline" className="flex items-center gap-1 uppercase">
+                            {Icon && <Icon className="h-3 w-3" aria-hidden="true" />}
+                            <span>{typeDisplayName}</span>
+                        </Badge>
+                    )}
+                </div>
+
+                {registrars.length > 0 && (
+                    <div className="flex flex-col gap-1">
+                        <span className="text-xs font-medium uppercase text-muted-foreground">Registrars</span>
+                        <span className="text-sm text-foreground">{registrars.join(', ')}</span>
+                    </div>
+                )}
+
+                {tld.description && <p className="text-xs leading-relaxed text-muted-foreground">{tld.description}</p>}
+            </div>
+        );
+    }
+
+    return (
+        <div className="min-h-screen">
+            <main className="m-auto flex w-full max-w-6xl flex-col items-center gap-5 p-5 md:p-10">
+                <div className="text-center">
+                    <Badge className="text-xs font-medium">TLD DIRECTORY</Badge>
+                    <h1 className="mt-4 text-2xl font-semibold lg:text-4xl">All Top-Level Domains</h1>
+                    <p className="mt-2 text-sm font-medium text-muted-foreground lg:mt-6 lg:text-base">
+                        Explore our complete collection of{' '}
+                        <Highlighter action="highlight" color="#fde2e4">
+                            {tlds.length} TLDs
+                        </Highlighter>
+                    </p>
+                </div>
+
+                <div className="mt-6 grid w-full gap-4 sm:grid-cols-2 lg:mt-14 lg:grid-cols-3">
+                    {tlds.map((tld) => (
+                        <TldListItem key={tld.name || tld.punycodeName} tld={tld} />
+                    ))}
+                </div>
+            </main>
+        </div>
+    );
+}

--- a/src/services/__tests__/api.test.ts
+++ b/src/services/__tests__/api.test.ts
@@ -89,6 +89,73 @@ describe('APIClient', () => {
         });
     });
 
+    describe('getTLDs', () => {
+        it('should return a list of all TLDs', async () => {
+            const mockTlds: TLD[] = [
+                {
+                    name: 'com',
+                    punycodeName: 'com',
+                    description: 'Commercial',
+                    type: TLDType.GENERIC,
+                    pricing: {
+                        [Registrar.DYNADOT]: {
+                            registration: 8.99,
+                            renewal: 8.99,
+                            currency: 'USD',
+                        },
+                    },
+                },
+                {
+                    name: 'dev',
+                    punycodeName: 'dev',
+                    description: 'Technology and development',
+                    type: TLDType.GENERIC,
+                    pricing: {
+                        [Registrar.GANDI]: {
+                            registration: 15.0,
+                            renewal: 15.0,
+                            currency: 'USD',
+                        },
+                    },
+                },
+                {
+                    name: 'uk',
+                    punycodeName: 'uk',
+                    description: 'United Kingdom',
+                    type: TLDType.COUNTRY_CODE,
+                },
+            ];
+
+            const mockResponse = { tlds: mockTlds };
+
+            mockAdapter.onGet('/api/tlds').reply(200, mockResponse);
+
+            const result = await apiClient.getTLDs();
+
+            expect(result).toEqual(mockTlds);
+        });
+
+        it('should return an empty array when no TLDs are returned', async () => {
+            const mockResponse = { tlds: [] };
+
+            mockAdapter.onGet('/api/tlds').reply(200, mockResponse);
+
+            const result = await apiClient.getTLDs();
+
+            expect(result).toEqual([]);
+        });
+
+        it('should return an empty array when tlds property is missing', async () => {
+            const mockResponse = {};
+
+            mockAdapter.onGet('/api/tlds').reply(200, mockResponse);
+
+            const result = await apiClient.getTLDs();
+
+            expect(result).toEqual([]);
+        });
+    });
+
     describe('getTLDsCount', () => {
         it('should return the number of TLDs', async () => {
             const mockCount = 100;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -38,6 +38,14 @@ class APIClient {
     /**
      * Gets all available TLDs.
      */
+    async getTLDs(): Promise<TLD[]> {
+        const response = await this.client.get('/api/tlds');
+        return response.data.tlds ?? [];
+    }
+
+    /**
+     * Gets all available TLDs count.
+     */
     async getTLDsCount(): Promise<number> {
         const response = await this.client.get('/api/tlds/count');
         return response.data.count ?? 0;


### PR DESCRIPTION
Add `/tlds` page with local `TldListItem` component and integrate TLD fetching via API client.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ea2914a-5c41-4424-aa55-2e25b6dfdeb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0ea2914a-5c41-4424-aa55-2e25b6dfdeb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

