### PR TITLE
Enhance security and refactor cron route tests and components

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -2,6 +2,10 @@ import '@testing-library/jest-dom';
 
 // Set up environment variables for tests
 process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY = 'test-amplitude-api-key';
+process.env.CRON_SECRET = 'test-cron-secret';
+process.env.NAMECOM_API_KEY = 'test-namecom-api-key';
+process.env.GANDI_API_KEY = 'test-gandi-api-key';
+process.env.NAMESILO_API_KEY = 'test-namesilo-api-key';
 process.env.NEXT_PUBLIC_ALGOLIA_APP_ID = 'test-algolia-app-id';
 process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_KEY = 'test-algolia-search-key';
 process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME = 'dictionary';

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,22 @@
 import type { NextConfig } from 'next';
 
-const nextConfig: NextConfig = {};
+const securityHeaders = [
+    { key: 'X-Content-Type-Options', value: 'nosniff' },
+    { key: 'X-Frame-Options', value: 'DENY' },
+    { key: 'X-XSS-Protection', value: '1; mode=block' },
+    { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+    { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+];
+
+const nextConfig: NextConfig = {
+    async headers() {
+        return [
+            {
+                source: '/(.*)',
+                headers: securityHeaders,
+            },
+        ];
+    },
+};
 
 export default nextConfig;

--- a/src/app/api/cron/dictionary/refresh/route.ts
+++ b/src/app/api/cron/dictionary/refresh/route.ts
@@ -16,7 +16,10 @@ const MAX_STALE_ENTRIES = 100;
 /**
  * Updates the dictionary of domain hacks.
  */
-export async function GET(): Promise<NextResponse> {
+export async function GET(request: Request): Promise<NextResponse> {
+    if (request.headers.get('authorization') !== `Bearer ${process.env.CRON_SECRET}`) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
     try {
         logger.info('Starting fetch stale dictionary ...');
         const lastUpdatedThreshold = subDays(new Date(), STALE_THRESHOLD_DAYS).toISOString();

--- a/src/app/api/cron/tlds/import/__tests__/route.test.ts
+++ b/src/app/api/cron/tlds/import/__tests__/route.test.ts
@@ -9,9 +9,30 @@ jest.mock('@/services/tld-repository');
 const mockAxios = axios as jest.Mocked<typeof axios>;
 const mockTldRepository = tldRepository as jest.Mocked<typeof tldRepository>;
 
+const authorizedRequest = () =>
+    new Request('http://localhost/api/cron/tlds/import', {
+        headers: { authorization: `Bearer ${process.env.CRON_SECRET}` },
+    });
+
 describe('/api/cron/tlds/import', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+    });
+
+    it('should return 401 when authorization header is missing', async () => {
+        const response = await GET(new Request('http://localhost/api/cron/tlds/import'));
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({ error: 'Unauthorized' });
+    });
+
+    it('should return 401 when authorization header is invalid', async () => {
+        const response = await GET(
+            new Request('http://localhost/api/cron/tlds/import', {
+                headers: { authorization: 'Bearer wrong-secret' },
+            }),
+        );
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({ error: 'Unauthorized' });
     });
 
     it('should successfully import TLDs from IANA', async () => {
@@ -22,7 +43,7 @@ describe('/api/cron/tlds/import', () => {
         mockAxios.get.mockResolvedValue(mockApiResponse);
         mockTldRepository.get.mockResolvedValue(null); // TLD doesn't exist
 
-        const response = await GET();
+        const response = await GET(authorizedRequest());
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -53,7 +74,7 @@ describe('/api/cron/tlds/import', () => {
         mockAxios.get.mockResolvedValue(mockApiResponse);
         mockTldRepository.get.mockResolvedValue(null);
 
-        const response = await GET();
+        const response = await GET(authorizedRequest());
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -71,7 +92,7 @@ describe('/api/cron/tlds/import', () => {
         const mockError = new Error('Network error');
         mockAxios.get.mockRejectedValue(mockError);
 
-        const response = await GET();
+        const response = await GET(authorizedRequest());
         const responseData = await response.json();
 
         expect(response.status).toBe(500);

--- a/src/app/api/cron/tlds/import/__tests__/route.test.ts
+++ b/src/app/api/cron/tlds/import/__tests__/route.test.ts
@@ -9,28 +9,22 @@ jest.mock('@/services/tld-repository');
 const mockAxios = axios as jest.Mocked<typeof axios>;
 const mockTldRepository = tldRepository as jest.Mocked<typeof tldRepository>;
 
-const authorizedRequest = () =>
-    new Request('http://localhost/api/cron/tlds/import', {
-        headers: { authorization: `Bearer ${process.env.CRON_SECRET}` },
-    });
-
 describe('/api/cron/tlds/import', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
     it('should return 401 when authorization header is missing', async () => {
-        const response = await GET(new Request('http://localhost/api/cron/tlds/import'));
+        const request = new Request('http://localhost/api/cron/tlds/import');
+        const response = await GET(request);
         expect(response.status).toBe(401);
         expect(await response.json()).toEqual({ error: 'Unauthorized' });
     });
 
     it('should return 401 when authorization header is invalid', async () => {
-        const response = await GET(
-            new Request('http://localhost/api/cron/tlds/import', {
-                headers: { authorization: 'Bearer wrong-secret' },
-            }),
-        );
+        const headers = { authorization: 'Bearer wrong-secret' };
+        const request = new Request('http://localhost/api/cron/tlds/import', { headers });
+        const response = await GET(request);
         expect(response.status).toBe(401);
         expect(await response.json()).toEqual({ error: 'Unauthorized' });
     });
@@ -43,7 +37,9 @@ describe('/api/cron/tlds/import', () => {
         mockAxios.get.mockResolvedValue(mockApiResponse);
         mockTldRepository.get.mockResolvedValue(null); // TLD doesn't exist
 
-        const response = await GET(authorizedRequest());
+        const headers = { authorization: `Bearer ${process.env.CRON_SECRET}` };
+        const request = new Request('http://localhost/api/cron/tlds/import', { headers });
+        const response = await GET(request);
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -74,7 +70,9 @@ describe('/api/cron/tlds/import', () => {
         mockAxios.get.mockResolvedValue(mockApiResponse);
         mockTldRepository.get.mockResolvedValue(null);
 
-        const response = await GET(authorizedRequest());
+        const headers = { authorization: `Bearer ${process.env.CRON_SECRET}` };
+        const request = new Request('http://localhost/api/cron/tlds/import', { headers });
+        const response = await GET(request);
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -92,7 +90,9 @@ describe('/api/cron/tlds/import', () => {
         const mockError = new Error('Network error');
         mockAxios.get.mockRejectedValue(mockError);
 
-        const response = await GET(authorizedRequest());
+        const headers = { authorization: `Bearer ${process.env.CRON_SECRET}` };
+        const request = new Request('http://localhost/api/cron/tlds/import', { headers });
+        const response = await GET(request);
         const responseData = await response.json();
 
         expect(response.status).toBe(500);

--- a/src/app/api/cron/tlds/import/route.ts
+++ b/src/app/api/cron/tlds/import/route.ts
@@ -8,7 +8,10 @@ import logger from '@/utils/logger';
 const IANA_TLD_URL = 'https://data.iana.org/TLD/tlds-alpha-by-domain.txt';
 export const maxDuration = 300; // This function can run for a maximum of 5 minutes
 
-export async function GET(): Promise<NextResponse> {
+export async function GET(request: Request): Promise<NextResponse> {
+    if (request.headers.get('authorization') !== `Bearer ${process.env.CRON_SECRET}`) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
     try {
         logger.info('Starting TLD import from IANA ...');
 

--- a/src/app/api/cron/tlds/update_description/__tests__/route.test.ts
+++ b/src/app/api/cron/tlds/update_description/__tests__/route.test.ts
@@ -13,11 +13,6 @@ const mockAxios = axios as jest.Mocked<typeof axios>;
 const mockTldRepository = tldRepository as jest.Mocked<typeof tldRepository>;
 const mockOpenAI = OpenAI as jest.MockedClass<typeof OpenAI>;
 
-const authorizedRequest = () =>
-    new Request('http://localhost/api/cron/tlds/update_description', {
-        headers: { authorization: `Bearer ${process.env.CRON_SECRET}` },
-    });
-
 describe('/api/cron/tlds/update_description', () => {
     const mockOpenAIClient = {
         chat: {
@@ -33,7 +28,8 @@ describe('/api/cron/tlds/update_description', () => {
     });
 
     it('should return 401 when authorization header is missing', async () => {
-        const response = await GET(new Request('http://localhost/api/cron/tlds/update_description'));
+        const request = new Request('http://localhost/api/cron/tlds/update_description');
+        const response = await GET(request);
         expect(response.status).toBe(401);
         expect(await response.json()).toEqual({ error: 'Unauthorized' });
     });
@@ -77,7 +73,9 @@ describe('/api/cron/tlds/update_description', () => {
         };
         mockOpenAIClient.chat.completions.create.mockResolvedValue(mockAIResponse);
 
-        const response = await GET(authorizedRequest());
+        const headers = { authorization: `Bearer ${process.env.CRON_SECRET}` };
+        const request = new Request('http://localhost/api/cron/tlds/update_description', { headers });
+        const response = await GET(request);
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -115,7 +113,9 @@ describe('/api/cron/tlds/update_description', () => {
 
         mockTldRepository.list.mockResolvedValue(mockTlds as any);
 
-        const response = await GET(authorizedRequest());
+        const headers = { authorization: `Bearer ${process.env.CRON_SECRET}` };
+        const request = new Request('http://localhost/api/cron/tlds/update_description', { headers });
+        const response = await GET(request);
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -141,7 +141,9 @@ describe('/api/cron/tlds/update_description', () => {
         mockTldRepository.list.mockResolvedValue(mockTlds as any);
         mockAxios.get.mockRejectedValue(new Error('Network error'));
 
-        const response = await GET(authorizedRequest());
+        const headers = { authorization: `Bearer ${process.env.CRON_SECRET}` };
+        const request = new Request('http://localhost/api/cron/tlds/update_description', { headers });
+        const response = await GET(request);
         const responseData = await response.json();
 
         expect(response.status).toBe(500);

--- a/src/app/api/cron/tlds/update_description/__tests__/route.test.ts
+++ b/src/app/api/cron/tlds/update_description/__tests__/route.test.ts
@@ -13,6 +13,11 @@ const mockAxios = axios as jest.Mocked<typeof axios>;
 const mockTldRepository = tldRepository as jest.Mocked<typeof tldRepository>;
 const mockOpenAI = OpenAI as jest.MockedClass<typeof OpenAI>;
 
+const authorizedRequest = () =>
+    new Request('http://localhost/api/cron/tlds/update_description', {
+        headers: { authorization: `Bearer ${process.env.CRON_SECRET}` },
+    });
+
 describe('/api/cron/tlds/update_description', () => {
     const mockOpenAIClient = {
         chat: {
@@ -25,6 +30,12 @@ describe('/api/cron/tlds/update_description', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockOpenAI.mockImplementation(() => mockOpenAIClient as any);
+    });
+
+    it('should return 401 when authorization header is missing', async () => {
+        const response = await GET(new Request('http://localhost/api/cron/tlds/update_description'));
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({ error: 'Unauthorized' });
     });
 
     it('should successfully enrich TLDs with description', async () => {
@@ -66,7 +77,7 @@ describe('/api/cron/tlds/update_description', () => {
         };
         mockOpenAIClient.chat.completions.create.mockResolvedValue(mockAIResponse);
 
-        const response = await GET();
+        const response = await GET(authorizedRequest());
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -104,7 +115,7 @@ describe('/api/cron/tlds/update_description', () => {
 
         mockTldRepository.list.mockResolvedValue(mockTlds as any);
 
-        const response = await GET();
+        const response = await GET(authorizedRequest());
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -130,7 +141,7 @@ describe('/api/cron/tlds/update_description', () => {
         mockTldRepository.list.mockResolvedValue(mockTlds as any);
         mockAxios.get.mockRejectedValue(new Error('Network error'));
 
-        const response = await GET();
+        const response = await GET(authorizedRequest());
         const responseData = await response.json();
 
         expect(response.status).toBe(500);

--- a/src/app/api/cron/tlds/update_description/route.ts
+++ b/src/app/api/cron/tlds/update_description/route.ts
@@ -12,7 +12,10 @@ export const maxDuration = 300; // This function can run for a maximum of 5 minu
  * Enrich TLDs with a description.
  * This function fetches the TLDs from the database and enriches them with a description.
  */
-export async function GET(): Promise<NextResponse> {
+export async function GET(request: Request): Promise<NextResponse> {
+    if (request.headers.get('authorization') !== `Bearer ${process.env.CRON_SECRET}`) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
     try {
         logger.info('Starting TLD enrichment with description ...');
         const openaiClient = new OpenAI({ apiKey: process.env['OPENAI_API_KEY'] });

--- a/src/app/api/cron/tlds/update_pricing/dynodot/__tests__/route.test.ts
+++ b/src/app/api/cron/tlds/update_pricing/dynodot/__tests__/route.test.ts
@@ -10,18 +10,14 @@ jest.mock('@/services/tld-repository');
 const mockAxios = axios as jest.Mocked<typeof axios>;
 const mockTldRepository = tldRepository as jest.Mocked<typeof tldRepository>;
 
-const authorizedRequest = () =>
-    new Request('http://localhost/api/cron/tlds/update_pricing/dynodot', {
-        headers: { authorization: `Bearer ${process.env.CRON_SECRET}` },
-    });
-
 describe('/api/cron/tlds/update_pricing/dynodot', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
     it('should return 401 when authorization header is missing', async () => {
-        const response = await GET(new Request('http://localhost/api/cron/tlds/update_pricing/dynodot'));
+        const request = new Request('http://localhost/api/cron/tlds/update_pricing/dynodot');
+        const response = await GET(request);
         expect(response.status).toBe(401);
         expect(await response.json()).toEqual({ error: 'Unauthorized' });
     });
@@ -46,7 +42,9 @@ describe('/api/cron/tlds/update_pricing/dynodot', () => {
         mockTldRepository.get.mockResolvedValueOnce(mockComTldInfo as any);
         mockTldRepository.update.mockResolvedValue();
 
-        const response = await GET(authorizedRequest());
+        const headers = { authorization: `Bearer ${process.env.CRON_SECRET}` };
+        const request = new Request('http://localhost/api/cron/tlds/update_pricing/dynodot', { headers });
+        const response = await GET(request);
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -63,7 +61,9 @@ describe('/api/cron/tlds/update_pricing/dynodot', () => {
         const mockError = new Error('Network error');
         mockAxios.get.mockRejectedValue(mockError);
 
-        const response = await GET(authorizedRequest());
+        const headers = { authorization: `Bearer ${process.env.CRON_SECRET}` };
+        const request = new Request('http://localhost/api/cron/tlds/update_pricing/dynodot', { headers });
+        const response = await GET(request);
         const responseData = await response.json();
 
         expect(response.status).toBe(500);

--- a/src/app/api/cron/tlds/update_pricing/dynodot/__tests__/route.test.ts
+++ b/src/app/api/cron/tlds/update_pricing/dynodot/__tests__/route.test.ts
@@ -10,9 +10,20 @@ jest.mock('@/services/tld-repository');
 const mockAxios = axios as jest.Mocked<typeof axios>;
 const mockTldRepository = tldRepository as jest.Mocked<typeof tldRepository>;
 
+const authorizedRequest = () =>
+    new Request('http://localhost/api/cron/tlds/update_pricing/dynodot', {
+        headers: { authorization: `Bearer ${process.env.CRON_SECRET}` },
+    });
+
 describe('/api/cron/tlds/update_pricing/dynodot', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+    });
+
+    it('should return 401 when authorization header is missing', async () => {
+        const response = await GET(new Request('http://localhost/api/cron/tlds/update_pricing/dynodot'));
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({ error: 'Unauthorized' });
     });
 
     it('should successfully update TLD pricing from Dynadot', async () => {
@@ -35,7 +46,7 @@ describe('/api/cron/tlds/update_pricing/dynodot', () => {
         mockTldRepository.get.mockResolvedValueOnce(mockComTldInfo as any);
         mockTldRepository.update.mockResolvedValue();
 
-        const response = await GET();
+        const response = await GET(authorizedRequest());
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -52,7 +63,7 @@ describe('/api/cron/tlds/update_pricing/dynodot', () => {
         const mockError = new Error('Network error');
         mockAxios.get.mockRejectedValue(mockError);
 
-        const response = await GET();
+        const response = await GET(authorizedRequest());
         const responseData = await response.json();
 
         expect(response.status).toBe(500);

--- a/src/app/api/cron/tlds/update_pricing/dynodot/route.ts
+++ b/src/app/api/cron/tlds/update_pricing/dynodot/route.ts
@@ -29,7 +29,10 @@ interface DynadotPricingResponse {
  * This function fetches the TLDs from the database and enriches them with the pricing information from Dynadot.
  * It then updates the TLDs in the database with the new pricing information.
  */
-export async function GET(): Promise<NextResponse> {
+export async function GET(request: Request): Promise<NextResponse> {
+    if (request.headers.get('authorization') !== `Bearer ${process.env.CRON_SECRET}`) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
     try {
         logger.info('Starting TLD pricing enrichment from Dynadot ...');
         const headers = { Authorization: `Bearer ${DYNADOT_API_KEY}`, Accept: 'application/json' };

--- a/src/app/api/cron/tlds/update_pricing/gandi/__tests__/route.test.ts
+++ b/src/app/api/cron/tlds/update_pricing/gandi/__tests__/route.test.ts
@@ -10,9 +10,20 @@ jest.mock('@/services/tld-repository');
 const mockAxios = axios as jest.Mocked<typeof axios>;
 const mockTldRepository = tldRepository as jest.Mocked<typeof tldRepository>;
 
+const authorizedRequest = () =>
+    new Request('http://localhost/api/cron/tlds/update_pricing/gandi', {
+        headers: { authorization: `Bearer ${process.env.CRON_SECRET}` },
+    });
+
 describe('/api/cron/tlds/update_pricing/gandi', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+    });
+
+    it('should return 401 when authorization header is missing', async () => {
+        const response = await GET(new Request('http://localhost/api/cron/tlds/update_pricing/gandi'));
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({ error: 'Unauthorized' });
     });
 
     it('should successfully update TLD pricing from Gandi', async () => {
@@ -25,7 +36,7 @@ describe('/api/cron/tlds/update_pricing/gandi', () => {
         mockTldRepository.get.mockResolvedValueOnce(mockTldInfo as any);
         mockTldRepository.update.mockResolvedValue();
 
-        const response = await GET();
+        const response = await GET(authorizedRequest());
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -40,7 +51,7 @@ describe('/api/cron/tlds/update_pricing/gandi', () => {
         const mockError = new Error('Network error');
         mockAxios.get.mockRejectedValue(mockError);
 
-        const response = await GET();
+        const response = await GET(authorizedRequest());
         const responseData = await response.json();
 
         expect(response.status).toBe(500);

--- a/src/app/api/cron/tlds/update_pricing/gandi/__tests__/route.test.ts
+++ b/src/app/api/cron/tlds/update_pricing/gandi/__tests__/route.test.ts
@@ -10,18 +10,14 @@ jest.mock('@/services/tld-repository');
 const mockAxios = axios as jest.Mocked<typeof axios>;
 const mockTldRepository = tldRepository as jest.Mocked<typeof tldRepository>;
 
-const authorizedRequest = () =>
-    new Request('http://localhost/api/cron/tlds/update_pricing/gandi', {
-        headers: { authorization: `Bearer ${process.env.CRON_SECRET}` },
-    });
-
 describe('/api/cron/tlds/update_pricing/gandi', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
     it('should return 401 when authorization header is missing', async () => {
-        const response = await GET(new Request('http://localhost/api/cron/tlds/update_pricing/gandi'));
+        const request = new Request('http://localhost/api/cron/tlds/update_pricing/gandi');
+        const response = await GET(request);
         expect(response.status).toBe(401);
         expect(await response.json()).toEqual({ error: 'Unauthorized' });
     });
@@ -36,7 +32,9 @@ describe('/api/cron/tlds/update_pricing/gandi', () => {
         mockTldRepository.get.mockResolvedValueOnce(mockTldInfo as any);
         mockTldRepository.update.mockResolvedValue();
 
-        const response = await GET(authorizedRequest());
+        const headers = { authorization: `Bearer ${process.env.CRON_SECRET}` };
+        const request = new Request('http://localhost/api/cron/tlds/update_pricing/gandi', { headers });
+        const response = await GET(request);
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -51,7 +49,9 @@ describe('/api/cron/tlds/update_pricing/gandi', () => {
         const mockError = new Error('Network error');
         mockAxios.get.mockRejectedValue(mockError);
 
-        const response = await GET(authorizedRequest());
+        const headers = { authorization: `Bearer ${process.env.CRON_SECRET}` };
+        const request = new Request('http://localhost/api/cron/tlds/update_pricing/gandi', { headers });
+        const response = await GET(request);
         const responseData = await response.json();
 
         expect(response.status).toBe(500);

--- a/src/app/api/cron/tlds/update_pricing/gandi/route.ts
+++ b/src/app/api/cron/tlds/update_pricing/gandi/route.ts
@@ -8,7 +8,6 @@ import logger from '@/utils/logger';
 
 export const maxDuration = 300; // This function can run for a maximum of 5 minutes
 
-const GANDI_API_KEY = process.env.GANDI_API_KEY;
 const GANDI_TLDS_URL = 'https://api.gandi.net/v5/domain/tlds';
 
 /**
@@ -25,10 +24,18 @@ type GandiTLDsResponse = Array<{
  * This function fetches the TLDs from Gandi API and enriches them with the pricing information.
  * It then updates the TLDs in the database with the new pricing information.
  */
-export async function GET(): Promise<NextResponse> {
+export async function GET(request: Request): Promise<NextResponse> {
+    if (request.headers.get('authorization') !== `Bearer ${process.env.CRON_SECRET}`) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const gandiApiKey = process.env.GANDI_API_KEY;
+    if (!gandiApiKey) {
+        logger.error('GANDI_API_KEY is not set');
+        return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    }
     try {
         logger.info('Starting TLD pricing enrichment from Gandi ...');
-        const headers = { Authorization: `Apikey ${GANDI_API_KEY}` };
+        const headers = { Authorization: `Apikey ${gandiApiKey}` };
         const response = await axios.get<GandiTLDsResponse>(GANDI_TLDS_URL, { headers });
         const tlds = response.data;
         for (const tldData of tlds) {

--- a/src/app/api/cron/tlds/update_pricing/namecom/__tests__/route.test.ts
+++ b/src/app/api/cron/tlds/update_pricing/namecom/__tests__/route.test.ts
@@ -10,18 +10,14 @@ jest.mock('@/services/tld-repository');
 const mockAxios = axios as jest.Mocked<typeof axios>;
 const mockTldRepository = tldRepository as jest.Mocked<typeof tldRepository>;
 
-const authorizedRequest = () =>
-    new Request('http://localhost/api/cron/tlds/update_pricing/namecom', {
-        headers: { authorization: `Bearer ${process.env.CRON_SECRET}` },
-    });
-
 describe('/api/cron/tlds/update_pricing/namecom', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
     it('should return 401 when authorization header is missing', async () => {
-        const response = await GET(new Request('http://localhost/api/cron/tlds/update_pricing/namecom'));
+        const request = new Request('http://localhost/api/cron/tlds/update_pricing/namecom');
+        const response = await GET(request);
         expect(response.status).toBe(401);
         expect(await response.json()).toEqual({ error: 'Unauthorized' });
     });
@@ -45,7 +41,9 @@ describe('/api/cron/tlds/update_pricing/namecom', () => {
         mockTldRepository.get.mockResolvedValueOnce(mockComTldInfo as any);
         mockTldRepository.update.mockResolvedValue();
 
-        const response = await GET(authorizedRequest());
+        const headers = { authorization: `Bearer ${process.env.CRON_SECRET}` };
+        const request = new Request('http://localhost/api/cron/tlds/update_pricing/namecom', { headers });
+        const response = await GET(request);
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -62,7 +60,9 @@ describe('/api/cron/tlds/update_pricing/namecom', () => {
         const mockError = new Error('Network error');
         mockAxios.get.mockRejectedValue(mockError);
 
-        const response = await GET(authorizedRequest());
+        const headers = { authorization: `Bearer ${process.env.CRON_SECRET}` };
+        const request = new Request('http://localhost/api/cron/tlds/update_pricing/namecom', { headers });
+        const response = await GET(request);
         const responseData = await response.json();
 
         expect(response.status).toBe(500);

--- a/src/app/api/cron/tlds/update_pricing/namecom/__tests__/route.test.ts
+++ b/src/app/api/cron/tlds/update_pricing/namecom/__tests__/route.test.ts
@@ -10,9 +10,20 @@ jest.mock('@/services/tld-repository');
 const mockAxios = axios as jest.Mocked<typeof axios>;
 const mockTldRepository = tldRepository as jest.Mocked<typeof tldRepository>;
 
+const authorizedRequest = () =>
+    new Request('http://localhost/api/cron/tlds/update_pricing/namecom', {
+        headers: { authorization: `Bearer ${process.env.CRON_SECRET}` },
+    });
+
 describe('/api/cron/tlds/update_pricing/namecom', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+    });
+
+    it('should return 401 when authorization header is missing', async () => {
+        const response = await GET(new Request('http://localhost/api/cron/tlds/update_pricing/namecom'));
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({ error: 'Unauthorized' });
     });
 
     it('should successfully update TLD pricing from Name.com', async () => {
@@ -34,7 +45,7 @@ describe('/api/cron/tlds/update_pricing/namecom', () => {
         mockTldRepository.get.mockResolvedValueOnce(mockComTldInfo as any);
         mockTldRepository.update.mockResolvedValue();
 
-        const response = await GET();
+        const response = await GET(authorizedRequest());
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -51,7 +62,7 @@ describe('/api/cron/tlds/update_pricing/namecom', () => {
         const mockError = new Error('Network error');
         mockAxios.get.mockRejectedValue(mockError);
 
-        const response = await GET();
+        const response = await GET(authorizedRequest());
         const responseData = await response.json();
 
         expect(response.status).toBe(500);

--- a/src/app/api/cron/tlds/update_pricing/namecom/route.ts
+++ b/src/app/api/cron/tlds/update_pricing/namecom/route.ts
@@ -7,7 +7,6 @@ import logger from '@/utils/logger';
 
 export const maxDuration = 300; // This function can run for a maximum of 5 minutes
 
-const NAMECOM_API_KEY = process.env.NAMECOM_API_KEY;
 const NAMECOM_PRICES_URL = `https://api.name.com/core/v1/tldpricing`;
 
 /**
@@ -28,10 +27,18 @@ interface NameComPricingResponse {
  * This function fetches the TLDs from the database and enriches them with the pricing information from Name.com.
  * It then updates the TLDs in the database with the new pricing information.
  */
-export async function GET(): Promise<NextResponse> {
+export async function GET(request: Request): Promise<NextResponse> {
+    if (request.headers.get('authorization') !== `Bearer ${process.env.CRON_SECRET}`) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const namecomApiKey = process.env.NAMECOM_API_KEY;
+    if (!namecomApiKey) {
+        logger.error('NAMECOM_API_KEY is not set');
+        return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    }
     try {
         logger.info('Starting TLD pricing enrichment from Name.com ...');
-        const headers = { Authorization: `Basic ${NAMECOM_API_KEY}` };
+        const headers = { Authorization: `Basic ${namecomApiKey}` };
         let page = 1;
         let hasMoreResults = true;
         const MAX_PAGES = 100;

--- a/src/app/api/cron/tlds/update_pricing/namesilo/__tests__/route.test.ts
+++ b/src/app/api/cron/tlds/update_pricing/namesilo/__tests__/route.test.ts
@@ -10,9 +10,20 @@ jest.mock('@/services/tld-repository');
 const mockAxios = axios as jest.Mocked<typeof axios>;
 const mockTldRepository = tldRepository as jest.Mocked<typeof tldRepository>;
 
+const authorizedRequest = () =>
+    new Request('http://localhost/api/cron/tlds/update_pricing/namesilo', {
+        headers: { authorization: `Bearer ${process.env.CRON_SECRET}` },
+    });
+
 describe('/api/cron/tlds/update_pricing/namesilo', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+    });
+
+    it('should return 401 when authorization header is missing', async () => {
+        const response = await GET(new Request('http://localhost/api/cron/tlds/update_pricing/namesilo'));
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({ error: 'Unauthorized' });
     });
 
     it('should successfully update TLD pricing from Namesilo', async () => {
@@ -32,7 +43,7 @@ describe('/api/cron/tlds/update_pricing/namesilo', () => {
         mockTldRepository.get.mockResolvedValueOnce(mockComTldInfo as any);
         mockTldRepository.update.mockResolvedValue();
 
-        const response = await GET();
+        const response = await GET(authorizedRequest());
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -49,7 +60,7 @@ describe('/api/cron/tlds/update_pricing/namesilo', () => {
         const mockError = new Error('Network error');
         mockAxios.get.mockRejectedValue(mockError);
 
-        const response = await GET();
+        const response = await GET(authorizedRequest());
         const responseData = await response.json();
 
         expect(response.status).toBe(500);

--- a/src/app/api/cron/tlds/update_pricing/namesilo/__tests__/route.test.ts
+++ b/src/app/api/cron/tlds/update_pricing/namesilo/__tests__/route.test.ts
@@ -10,18 +10,14 @@ jest.mock('@/services/tld-repository');
 const mockAxios = axios as jest.Mocked<typeof axios>;
 const mockTldRepository = tldRepository as jest.Mocked<typeof tldRepository>;
 
-const authorizedRequest = () =>
-    new Request('http://localhost/api/cron/tlds/update_pricing/namesilo', {
-        headers: { authorization: `Bearer ${process.env.CRON_SECRET}` },
-    });
-
 describe('/api/cron/tlds/update_pricing/namesilo', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
     it('should return 401 when authorization header is missing', async () => {
-        const response = await GET(new Request('http://localhost/api/cron/tlds/update_pricing/namesilo'));
+        const request = new Request('http://localhost/api/cron/tlds/update_pricing/namesilo');
+        const response = await GET(request);
         expect(response.status).toBe(401);
         expect(await response.json()).toEqual({ error: 'Unauthorized' });
     });
@@ -43,7 +39,9 @@ describe('/api/cron/tlds/update_pricing/namesilo', () => {
         mockTldRepository.get.mockResolvedValueOnce(mockComTldInfo as any);
         mockTldRepository.update.mockResolvedValue();
 
-        const response = await GET(authorizedRequest());
+        const headers = { authorization: `Bearer ${process.env.CRON_SECRET}` };
+        const request = new Request('http://localhost/api/cron/tlds/update_pricing/namesilo', { headers });
+        const response = await GET(request);
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -60,7 +58,9 @@ describe('/api/cron/tlds/update_pricing/namesilo', () => {
         const mockError = new Error('Network error');
         mockAxios.get.mockRejectedValue(mockError);
 
-        const response = await GET(authorizedRequest());
+        const headers = { authorization: `Bearer ${process.env.CRON_SECRET}` };
+        const request = new Request('http://localhost/api/cron/tlds/update_pricing/namesilo', { headers });
+        const response = await GET(request);
         const responseData = await response.json();
 
         expect(response.status).toBe(500);

--- a/src/app/api/cron/tlds/update_pricing/namesilo/route.ts
+++ b/src/app/api/cron/tlds/update_pricing/namesilo/route.ts
@@ -7,8 +7,7 @@ import logger from '@/utils/logger';
 
 export const maxDuration = 300; // This function can run for a maximum of 5 minutes
 
-const NAMESILO_API_KEY = process.env.NAMESILO_API_KEY;
-const NAMESILO_PRICES_URL = `https://www.namesilo.com/api/getPrices?version=1&type=json&key=${NAMESILO_API_KEY}`;
+const NAMESILO_PRICES_BASE_URL = `https://www.namesilo.com/api/getPrices?version=1&type=json`;
 
 /**
  * The response from the Namesilo API for pricing information.
@@ -28,10 +27,18 @@ interface NamesiloPricingResponse {
  * This function fetches the TLDs from the database and enriches them with the pricing information from Namesilo.
  * It then updates the TLDs in the database with the new pricing information.
  */
-export async function GET(): Promise<NextResponse> {
+export async function GET(request: Request): Promise<NextResponse> {
+    if (request.headers.get('authorization') !== `Bearer ${process.env.CRON_SECRET}`) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const namesiloApiKey = process.env.NAMESILO_API_KEY;
+    if (!namesiloApiKey) {
+        logger.error('NAMESILO_API_KEY is not set');
+        return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    }
     try {
         logger.info('Starting TLD pricing enrichment from Namesilo ...');
-        const response = await axios.get<NamesiloPricingResponse>(NAMESILO_PRICES_URL);
+        const response = await axios.get<NamesiloPricingResponse>(`${NAMESILO_PRICES_BASE_URL}&key=${namesiloApiKey}`);
         const tlds = Object.keys(response.data.reply).map((tld) => tld.toLowerCase());
         for (const tld of tlds) {
             const tldInfo = await tldRepository.get(tld);

--- a/src/app/api/cron/tlds/update_pricing/porkbun/__tests__/route.test.ts
+++ b/src/app/api/cron/tlds/update_pricing/porkbun/__tests__/route.test.ts
@@ -10,18 +10,14 @@ jest.mock('@/services/tld-repository');
 const mockAxios = axios as jest.Mocked<typeof axios>;
 const mockTldRepository = tldRepository as jest.Mocked<typeof tldRepository>;
 
-const authorizedRequest = () =>
-    new Request('http://localhost/api/cron/tlds/update_pricing/porkbun', {
-        headers: { authorization: `Bearer ${process.env.CRON_SECRET}` },
-    });
-
 describe('/api/cron/tlds/update_pricing/porkbun', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
     it('should return 401 when authorization header is missing', async () => {
-        const response = await GET(new Request('http://localhost/api/cron/tlds/update_pricing/porkbun'));
+        const request = new Request('http://localhost/api/cron/tlds/update_pricing/porkbun');
+        const response = await GET(request);
         expect(response.status).toBe(401);
         expect(await response.json()).toEqual({ error: 'Unauthorized' });
     });
@@ -48,7 +44,9 @@ describe('/api/cron/tlds/update_pricing/porkbun', () => {
         mockTldRepository.get.mockResolvedValueOnce(mockComTldInfo as any);
         mockTldRepository.update.mockResolvedValue();
 
-        const response = await GET(authorizedRequest());
+        const headers = { authorization: `Bearer ${process.env.CRON_SECRET}` };
+        const request = new Request('http://localhost/api/cron/tlds/update_pricing/porkbun', { headers });
+        const response = await GET(request);
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -65,7 +63,9 @@ describe('/api/cron/tlds/update_pricing/porkbun', () => {
         const mockError = new Error('Network error');
         mockAxios.get.mockRejectedValue(mockError);
 
-        const response = await GET(authorizedRequest());
+        const headers = { authorization: `Bearer ${process.env.CRON_SECRET}` };
+        const request = new Request('http://localhost/api/cron/tlds/update_pricing/porkbun', { headers });
+        const response = await GET(request);
         const responseData = await response.json();
 
         expect(response.status).toBe(500);

--- a/src/app/api/cron/tlds/update_pricing/porkbun/__tests__/route.test.ts
+++ b/src/app/api/cron/tlds/update_pricing/porkbun/__tests__/route.test.ts
@@ -10,9 +10,20 @@ jest.mock('@/services/tld-repository');
 const mockAxios = axios as jest.Mocked<typeof axios>;
 const mockTldRepository = tldRepository as jest.Mocked<typeof tldRepository>;
 
+const authorizedRequest = () =>
+    new Request('http://localhost/api/cron/tlds/update_pricing/porkbun', {
+        headers: { authorization: `Bearer ${process.env.CRON_SECRET}` },
+    });
+
 describe('/api/cron/tlds/update_pricing/porkbun', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+    });
+
+    it('should return 401 when authorization header is missing', async () => {
+        const response = await GET(new Request('http://localhost/api/cron/tlds/update_pricing/porkbun'));
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({ error: 'Unauthorized' });
     });
 
     it('should successfully update TLD pricing from Porkbun', async () => {
@@ -37,7 +48,7 @@ describe('/api/cron/tlds/update_pricing/porkbun', () => {
         mockTldRepository.get.mockResolvedValueOnce(mockComTldInfo as any);
         mockTldRepository.update.mockResolvedValue();
 
-        const response = await GET();
+        const response = await GET(authorizedRequest());
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -54,7 +65,7 @@ describe('/api/cron/tlds/update_pricing/porkbun', () => {
         const mockError = new Error('Network error');
         mockAxios.get.mockRejectedValue(mockError);
 
-        const response = await GET();
+        const response = await GET(authorizedRequest());
         const responseData = await response.json();
 
         expect(response.status).toBe(500);

--- a/src/app/api/cron/tlds/update_pricing/porkbun/route.ts
+++ b/src/app/api/cron/tlds/update_pricing/porkbun/route.ts
@@ -30,7 +30,10 @@ interface PorkbunPricingResponse {
  * This function fetches the TLDs from the database and enriches them with the pricing information from Porkbun.
  * It then updates the TLDs in the database with the new pricing information.
  */
-export async function GET(): Promise<NextResponse> {
+export async function GET(request: Request): Promise<NextResponse> {
+    if (request.headers.get('authorization') !== `Bearer ${process.env.CRON_SECRET}`) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
     try {
         logger.info('Starting TLD pricing enrichment from Porkbun ...');
         const response = await axios.get<PorkbunPricingResponse>(PORKBUN_PRICES_URL);

--- a/src/app/api/cron/tlds/update_type/__tests__/route.test.ts
+++ b/src/app/api/cron/tlds/update_type/__tests__/route.test.ts
@@ -11,9 +11,20 @@ jest.mock('@/services/tld-repository');
 const mockAxios = axios as jest.Mocked<typeof axios>;
 const mockTldRepository = tldRepository as jest.Mocked<typeof tldRepository>;
 
+const authorizedRequest = () =>
+    new Request('http://localhost/api/cron/tlds/update_type', {
+        headers: { authorization: `Bearer ${process.env.CRON_SECRET}` },
+    });
+
 describe('/api/cron/tlds/update_type', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+    });
+
+    it('should return 401 when authorization header is missing', async () => {
+        const response = await GET(new Request('http://localhost/api/cron/tlds/update_type'));
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({ error: 'Unauthorized' });
     });
 
     it('should successfully enrich TLDs with type and organization', async () => {
@@ -61,7 +72,7 @@ describe('/api/cron/tlds/update_type', () => {
         const cheerio = jest.mocked(await import('cheerio'));
         cheerio.load.mockReturnValue(mockCheerioInstance as any);
 
-        const response = await GET();
+        const response = await GET(authorizedRequest());
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -93,7 +104,7 @@ describe('/api/cron/tlds/update_type', () => {
         mockTldRepository.list.mockResolvedValue(mockTlds as any);
         mockAxios.get.mockResolvedValue({ data: '<table></table>' });
 
-        const response = await GET();
+        const response = await GET(authorizedRequest());
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -116,7 +127,7 @@ describe('/api/cron/tlds/update_type', () => {
         mockTldRepository.list.mockResolvedValue(mockTlds as any);
         mockAxios.get.mockRejectedValue(new Error('Network error'));
 
-        const response = await GET();
+        const response = await GET(authorizedRequest());
         const responseData = await response.json();
 
         expect(response.status).toBe(500);

--- a/src/app/api/cron/tlds/update_type/__tests__/route.test.ts
+++ b/src/app/api/cron/tlds/update_type/__tests__/route.test.ts
@@ -11,18 +11,14 @@ jest.mock('@/services/tld-repository');
 const mockAxios = axios as jest.Mocked<typeof axios>;
 const mockTldRepository = tldRepository as jest.Mocked<typeof tldRepository>;
 
-const authorizedRequest = () =>
-    new Request('http://localhost/api/cron/tlds/update_type', {
-        headers: { authorization: `Bearer ${process.env.CRON_SECRET}` },
-    });
-
 describe('/api/cron/tlds/update_type', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
     it('should return 401 when authorization header is missing', async () => {
-        const response = await GET(new Request('http://localhost/api/cron/tlds/update_type'));
+        const request = new Request('http://localhost/api/cron/tlds/update_type');
+        const response = await GET(request);
         expect(response.status).toBe(401);
         expect(await response.json()).toEqual({ error: 'Unauthorized' });
     });
@@ -72,7 +68,9 @@ describe('/api/cron/tlds/update_type', () => {
         const cheerio = jest.mocked(await import('cheerio'));
         cheerio.load.mockReturnValue(mockCheerioInstance as any);
 
-        const response = await GET(authorizedRequest());
+        const headers = { authorization: `Bearer ${process.env.CRON_SECRET}` };
+        const request = new Request('http://localhost/api/cron/tlds/update_type', { headers });
+        const response = await GET(request);
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -104,7 +102,9 @@ describe('/api/cron/tlds/update_type', () => {
         mockTldRepository.list.mockResolvedValue(mockTlds as any);
         mockAxios.get.mockResolvedValue({ data: '<table></table>' });
 
-        const response = await GET(authorizedRequest());
+        const headers = { authorization: `Bearer ${process.env.CRON_SECRET}` };
+        const request = new Request('http://localhost/api/cron/tlds/update_type', { headers });
+        const response = await GET(request);
         const responseData = await response.json();
 
         expect(response.status).toBe(200);
@@ -127,7 +127,9 @@ describe('/api/cron/tlds/update_type', () => {
         mockTldRepository.list.mockResolvedValue(mockTlds as any);
         mockAxios.get.mockRejectedValue(new Error('Network error'));
 
-        const response = await GET(authorizedRequest());
+        const headers = { authorization: `Bearer ${process.env.CRON_SECRET}` };
+        const request = new Request('http://localhost/api/cron/tlds/update_type', { headers });
+        const response = await GET(request);
         const responseData = await response.json();
 
         expect(response.status).toBe(500);

--- a/src/app/api/cron/tlds/update_type/route.ts
+++ b/src/app/api/cron/tlds/update_type/route.ts
@@ -12,7 +12,10 @@ export const maxDuration = 300; // This function can run for a maximum of 5 minu
  * Enrich TLDs with their type and organization.
  * This function fetches the TLDs from the database and enriches them with their type and organization.
  */
-export async function GET(): Promise<NextResponse> {
+export async function GET(request: Request): Promise<NextResponse> {
+    if (request.headers.get('authorization') !== `Bearer ${process.env.CRON_SECRET}`) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
     try {
         logger.info('Starting TLD enrichment with type and organization ...');
         const ianaResponse = await axios.get(`https://www.iana.org/domains/root/db`);

--- a/src/app/tlds/page.tsx
+++ b/src/app/tlds/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState, useTransition } from 'react';
 import { search } from 'fast-fuzzy';
-import { motion } from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
 import { Search } from 'lucide-react';
 
 import ErrorMessage from '@/components/ErrorMessage';
@@ -121,37 +121,42 @@ export default function TldsPage() {
 
                 <div className="mt-3 w-full lg:mt-6">
                     <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                        {filteredTlds.map((tld, idx) => (
-                            <motion.div
-                                key={tld.name}
-                                initial={{ opacity: 0, y: 20 }}
-                                animate={{ opacity: 1, y: 0 }}
-                                transition={{
-                                    duration: 0.5,
-                                    delay: Math.min(idx * 0.02, 0.3),
-                                    ease: 'easeOut',
-                                }}
-                            >
-                                <Card
-                                    className={cn(
-                                        'group relative cursor-pointer overflow-hidden rounded-sm border-[0.5px] transition-all duration-200 hover:scale-[1.02] hover:shadow-lg',
-                                        'border-gray-200 bg-white hover:border-gray-300 hover:shadow-gray-200/40',
-                                    )}
-                                    onClick={() => showDrawer(tld)}
+                        <AnimatePresence mode="popLayout">
+                            {filteredTlds.map((tld, idx) => (
+                                <motion.div
+                                    key={tld.name}
+                                    layout
+                                    initial={{ opacity: 0, y: 20 }}
+                                    animate={{ opacity: 1, y: 0 }}
+                                    exit={{ opacity: 0, scale: 0.95 }}
+                                    transition={{
+                                        duration: 0.3,
+                                        delay: Math.min(idx * 0.02, 0.3),
+                                        ease: 'easeOut',
+                                        layout: { duration: 0.2 },
+                                    }}
                                 >
-                                    <CardContent className="p-3">
-                                        <div className="flex flex-col gap-1">
-                                            <h3 className="flex min-w-0 items-center gap-2 truncate text-sm font-semibold transition-colors group-hover:text-primary">
-                                                .{tld.name}
-                                            </h3>
-                                            <span className="shrink-0 text-xs font-light lowercase text-muted-foreground">
-                                                {tld.type ? TLD_TYPE_DISPLAY_NAMES[tld.type] : 'Unknown'}
-                                            </span>
-                                        </div>
-                                    </CardContent>
-                                </Card>
-                            </motion.div>
-                        ))}
+                                    <Card
+                                        className={cn(
+                                            'group relative cursor-pointer overflow-hidden rounded-sm border-[0.5px] transition-all duration-200 hover:scale-[1.02] hover:shadow-lg',
+                                            'border-gray-200 bg-white hover:border-gray-300 hover:shadow-gray-200/40',
+                                        )}
+                                        onClick={() => showDrawer(tld)}
+                                    >
+                                        <CardContent className="p-3">
+                                            <div className="flex flex-col gap-1">
+                                                <h3 className="flex min-w-0 items-center gap-2 truncate text-sm font-semibold transition-colors group-hover:text-primary">
+                                                    .{tld.name}
+                                                </h3>
+                                                <span className="shrink-0 text-xs font-light lowercase text-muted-foreground">
+                                                    {tld.type ? TLD_TYPE_DISPLAY_NAMES[tld.type] : 'Unknown'}
+                                                </span>
+                                            </div>
+                                        </CardContent>
+                                    </Card>
+                                </motion.div>
+                            ))}
+                        </AnimatePresence>
                     </div>
                 </div>
             </main>

--- a/src/components/SearchResult.tsx
+++ b/src/components/SearchResult.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 
 import DomainDetailDrawer from '@/components/DomainDetailDrawer';
 import DomainStatusBadge from '@/components/DomainStatusBadge';
@@ -9,7 +9,7 @@ import { Domain, DomainStatus as DomainStatusEnum } from '@/models/domain';
 import { apiClient } from '@/services/api';
 import { rateLimiter } from '@/utils/rate-limiter';
 
-export function SearchResult({ domain }: { domain: Domain }) {
+export const SearchResult = memo(({ domain }: { domain: Domain }) => {
     const [status, setStatus] = useState<DomainStatusEnum>(DomainStatusEnum.UNKNOWN);
     const [open, setOpen] = useState(false);
 
@@ -45,4 +45,4 @@ export function SearchResult({ domain }: { domain: Domain }) {
             <DomainDetailDrawer domain={domain} open={open} onClose={() => setOpen(false)} />
         </>
     );
-}
+});

--- a/src/services/__tests__/tld-repository.test.ts
+++ b/src/services/__tests__/tld-repository.test.ts
@@ -288,12 +288,12 @@ describe('TLDRepository', () => {
         };
 
         it('should update TLD and invalidate cache', async () => {
+            const mockUpdate = jest.fn().mockReturnValue({
+                eq: jest.fn().mockResolvedValue({ error: null }),
+            });
+
             mockSupabaseClient.from = jest.fn().mockReturnValue({
-                update: jest.fn().mockReturnValue({
-                    eq: jest.fn().mockResolvedValue({
-                        error: null,
-                    }),
-                }),
+                update: mockUpdate,
             });
 
             await tldRepository.update('com', mockTLD);
@@ -301,6 +301,31 @@ describe('TLDRepository', () => {
             expect(mockSupabaseClient.from).toHaveBeenCalledWith('tld');
             expect(mockCache.delete).toHaveBeenCalledWith('tlds');
             expect(mockCache.delete).toHaveBeenCalledWith('tld:com');
+        });
+
+        it('should lowercase name and punycode_name in the update payload', async () => {
+            const mixedCaseTld: TLD = {
+                ...mockTLD,
+                name: 'COM',
+                punycodeName: 'COM',
+            };
+
+            const mockUpdate = jest.fn().mockReturnValue({
+                eq: jest.fn().mockResolvedValue({ error: null }),
+            });
+
+            mockSupabaseClient.from = jest.fn().mockReturnValue({
+                update: mockUpdate,
+            });
+
+            await tldRepository.update('COM', mixedCaseTld);
+
+            expect(mockUpdate).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    name: 'com',
+                    punycode_name: 'com',
+                }),
+            );
         });
 
         it('should search by punycode_name when name starts with xn--', async () => {

--- a/src/services/tld-repository.ts
+++ b/src/services/tld-repository.ts
@@ -142,10 +142,10 @@ class TLDRepository {
             .update({
                 country_code: tld.countryCode,
                 description: tld.description,
-                name: tld.name,
+                name: tld.name?.toLowerCase(),
                 organization: tld.organization,
                 pricing: tld.pricing,
-                punycode_name: tld.punycodeName,
+                punycode_name: tld.punycodeName?.toLowerCase(),
                 tagline: tld.tagline,
                 type: tld.type,
                 updated_at: new Date().toISOString(),


### PR DESCRIPTION
This pull request introduces security improvements to the cron-related API endpoints by requiring an authorization header for access, updates related tests to reflect this change, and adds security headers to all HTTP responses. It also improves environment variable setup for tests and enhances error handling for missing API keys.

**Security improvements for API endpoints:**

* All cron API endpoints (`/api/cron/dictionary/refresh`, `/api/cron/tlds/import`, `/api/cron/tlds/update_description`, `/api/cron/tlds/update_pricing/dynodot`, `/api/cron/tlds/update_pricing/gandi`, `/api/cron/tlds/update_pricing/namecom`) now require an `Authorization` header with a bearer token matching `process.env.CRON_SECRET`. Unauthorized requests receive a 401 response. [[1]](diffhunk://#diff-e00a4dd32ca9251bb79e976da6367c77f35264df43d4d87a0e3a9b012a1f4dfaL19-R22) [[2]](diffhunk://#diff-4421b8c369e257bd64560753af5d081a72edf7ed316a31ae04bb8109fd27ecefL11-R14) [[3]](diffhunk://#diff-7be75c0796fbded0a32cb6fb0fa3b9203dd4a569f568772df9f370309ea27d75L15-R18) [[4]](diffhunk://#diff-f6e114adaa1f3c3d80088d62e34198be78a655a5e89690960c3d22224d80f0f9L32-R35) [[5]](diffhunk://#diff-778a32d1300ab1d0067d082e7d19851252d4768ace1cd3a683ecf1af091aa9f8L28-R38)
* Improved error handling for the Gandi endpoint: returns a 500 error if the `GANDI_API_KEY` is missing, with a log message for easier debugging.

**Test updates:**

* All affected API endpoint tests now include cases for missing or invalid authorization headers and update existing tests to provide the correct header. [[1]](diffhunk://#diff-fa3d57ba25c4cfed2845d931cb01510bd1d31eece2f9e4aa38b17516dce5330cR17-R31) [[2]](diffhunk://#diff-fa3d57ba25c4cfed2845d931cb01510bd1d31eece2f9e4aa38b17516dce5330cL25-R42) [[3]](diffhunk://#diff-fa3d57ba25c4cfed2845d931cb01510bd1d31eece2f9e4aa38b17516dce5330cL56-R75) [[4]](diffhunk://#diff-fa3d57ba25c4cfed2845d931cb01510bd1d31eece2f9e4aa38b17516dce5330cL74-R95) [[5]](diffhunk://#diff-7de1f1c672ca07cd2ade889e770f261ca2fae6299faba81eef6383ea5de94fdaR30-R36) [[6]](diffhunk://#diff-7de1f1c672ca07cd2ade889e770f261ca2fae6299faba81eef6383ea5de94fdaL69-R78) [[7]](diffhunk://#diff-7de1f1c672ca07cd2ade889e770f261ca2fae6299faba81eef6383ea5de94fdaL107-R118) [[8]](diffhunk://#diff-7de1f1c672ca07cd2ade889e770f261ca2fae6299faba81eef6383ea5de94fdaL133-R146) [[9]](diffhunk://#diff-dbf802fa348889a9239887550e7b056eb3d792f6c632c6127686e88a53bad755R18-R24) [[10]](diffhunk://#diff-dbf802fa348889a9239887550e7b056eb3d792f6c632c6127686e88a53bad755L38-R47) [[11]](diffhunk://#diff-dbf802fa348889a9239887550e7b056eb3d792f6c632c6127686e88a53bad755L55-R66) [[12]](diffhunk://#diff-8d965cf31d6f7b30c585532eda2a16ea994a155e1df740d141d2bb9a50854723R18-R24) [[13]](diffhunk://#diff-8d965cf31d6f7b30c585532eda2a16ea994a155e1df740d141d2bb9a50854723L28-R37) [[14]](diffhunk://#diff-8d965cf31d6f7b30c585532eda2a16ea994a155e1df740d141d2bb9a50854723L43-R54) [[15]](diffhunk://#diff-a44e49c4c5bc80a764a748b5d52f1e9768779a4c4fba6154bcc9ff67988e3108R18-R24) [[16]](diffhunk://#diff-a44e49c4c5bc80a764a748b5d52f1e9768779a4c4fba6154bcc9ff67988e3108L37-R46) [[17]](diffhunk://#diff-a44e49c4c5bc80a764a748b5d52f1e9768779a4c4fba6154bcc9ff67988e3108L54-R65)

**Security headers:**

* Adds standard security headers (e.g., `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Referrer-Policy`, `Permissions-Policy`) to all HTTP responses via `next.config.ts`.

**Test environment improvements:**

* Adds missing API key environment variables (`CRON_SECRET`, `NAMECOM_API_KEY`, `GANDI_API_KEY`, `NAMESILO_API_KEY`) to `jest.setup.ts` for more comprehensive test coverage.

**Code cleanup:**

* Removes unused direct assignments of `GANDI_API_KEY` and `NAMECOM_API_KEY` at the top of their respective route files, now retrieving them within the function as needed. [[1]](diffhunk://#diff-778a32d1300ab1d0067d082e7d19851252d4768ace1cd3a683ecf1af091aa9f8L11) [[2]](diffhunk://#diff-c606e39442531e0b2c21b89e260c82578a98afb0fa09f9f80127f4b6c4dbbddfL10)