### PR TITLE
Fix duplicate initials for Name.com and NameSilo registrar buttons

### DIFF
--- a/src/components/DomainRegistrarButtons.tsx
+++ b/src/components/DomainRegistrarButtons.tsx
@@ -7,6 +7,7 @@ import {
     REGISTRAR_DISPLAY_NAMES,
     REGISTRAR_DOMAIN_SEARCH_URLS,
     REGISTRAR_ICON_COLORS,
+    REGISTRAR_INITIALS,
     TLDPricing,
 } from '@/models/tld';
 
@@ -46,7 +47,7 @@ function DomainRegistrarButtons({ domainName, pricing, isPremiumDomain }: Domain
                     const registrar = registrarKey as Registrar;
                     const searchUrl = REGISTRAR_DOMAIN_SEARCH_URLS[registrar];
                     const displayName = REGISTRAR_DISPLAY_NAMES[registrar];
-                    const initials = displayName.slice(0, 2).toUpperCase();
+                    const initials = REGISTRAR_INITIALS[registrar];
                     const iconColor = REGISTRAR_ICON_COLORS[registrar];
                     const registrationPrice = registrarPricing?.registration;
                     const hasPricing = typeof registrationPrice === 'number';

--- a/src/models/tld.ts
+++ b/src/models/tld.ts
@@ -61,6 +61,14 @@ export interface TLD {
     yearEstablished?: number;
 }
 
+export const REGISTRAR_INITIALS: Record<Registrar, string> = {
+    [Registrar.DYNADOT]: 'DY',
+    [Registrar.GANDI]: 'GA',
+    [Registrar.NAMECOM]: 'NC',
+    [Registrar.NAMESILO]: 'NS',
+    [Registrar.PORKBUN]: 'PO',
+};
+
 export const REGISTRAR_ICON_COLORS: Record<Registrar, string> = {
     [Registrar.DYNADOT]: 'bg-blue-500',
     [Registrar.GANDI]: 'bg-sky-600',


### PR DESCRIPTION
## Summary

- Both Name.com and NameSilo produced `"NA"` as initials via `displayName.slice(0, 2).toUpperCase()`, making their icons indistinguishable
- Added `REGISTRAR_INITIALS` constant in `src/models/tld.ts` with explicit, unique initials per registrar
- Updated `DomainRegistrarButtons.tsx` to use the new constant instead of the string-slicing logic

| Registrar | Before | After |
|-----------|--------|-------|
| Dynadot   | DY     | DY    |
| Gandi     | GA     | GA    |
| Name.com  | ~~NA~~ | **NC** |
| NameSilo  | ~~NA~~ | **NS** |
| Porkbun   | PO     | PO    |

## Test plan

- [ ] Verify registrar buttons show distinct initials for all 5 registrars
- [ ] Confirm Name.com shows `NC` and NameSilo shows `NS`
- [ ] Existing tests pass

https://claude.ai/code/session_01Sr37gSmSBYMZCBQ8gPtjxN