### PR TITLE
Use pastel colors and black text for registrar icons

### DIFF
--- a/src/components/DomainRegistrarButtons.tsx
+++ b/src/components/DomainRegistrarButtons.tsx
@@ -60,7 +60,8 @@ function DomainRegistrarButtons({ domainName, pricing, isPremiumDomain }: Domain
                             className="flex items-center gap-3 rounded-lg border border-gray-200 bg-white p-2.5 transition-all hover:border-blue-400 hover:bg-blue-50/40 hover:shadow-sm"
                         >
                             <div
-                                className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-xs font-bold text-white ${iconColor}`}
+                                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-xs font-bold text-black"
+                                style={{ backgroundColor: iconColor }}
                             >
                                 {initials}
                             </div>

--- a/src/models/tld.ts
+++ b/src/models/tld.ts
@@ -70,11 +70,11 @@ export const REGISTRAR_INITIALS: Record<Registrar, string> = {
 };
 
 export const REGISTRAR_ICON_COLORS: Record<Registrar, string> = {
-    [Registrar.DYNADOT]: 'bg-blue-500',
-    [Registrar.GANDI]: 'bg-cyan-500',
-    [Registrar.NAMECOM]: 'bg-teal-500',
-    [Registrar.NAMESILO]: 'bg-green-500',
-    [Registrar.PORKBUN]: 'bg-purple-500',
+    [Registrar.DYNADOT]: '#a9def9',
+    [Registrar.GANDI]: '#fcf6bd',
+    [Registrar.NAMECOM]: '#d0f4de',
+    [Registrar.NAMESILO]: '#e4c1f9',
+    [Registrar.PORKBUN]: '#ffd6e7',
 };
 
 export const TLD_TYPE_DISPLAY_NAMES: Record<TLDType, string> = {


### PR DESCRIPTION
Replace saturated Tailwind bg-*-500 classes with homepage-matching pastel
hex colors (#a9def9, #fcf6bd, #d0f4de, #e4c1f9, #ffd6e7) and switch text
from white to black for legibility on light backgrounds.

https://claude.ai/code/session_01VjZkT5tj4uX2XhZAyWnauT